### PR TITLE
Change `ensure => present` to `ensure => file` for file resources

### DIFF
--- a/quests/modules.md
+++ b/quests/modules.md
@@ -202,8 +202,9 @@ In this case, the `.vimrc` file that defines your Vim settings lives in the
 This resource declaration will then need two attribute value pairs.
 
 First, as with the other resource types you've encountered, `ensure =>
-present,` tells Puppet to ensure that the entity described by the resource
-exists on the system. 
+present,` would tell Puppet to ensure that the entity described by the resource
+exists on the system. However, because Linux uses files for both "normal" files
+and directories, we'll want to use the more explicit `ensure => file,` instead.
 
 Second, the `source` attribute tells Puppet what the managed file should
 actually contain. The value for the source attribute should be the URI of the
@@ -243,7 +244,7 @@ Putting this all together, your `init.pp` manifest should contain the following:
 ```puppet
 class vimrc {
   file { '/root/.vimrc':
-    ensure => present,
+    ensure => file,
     source => 'puppet:///modules/vimrc/vimrc',
   }
 }

--- a/quests/resource_ordering.md
+++ b/quests/resource_ordering.md
@@ -179,7 +179,7 @@ class sshd {
   ...
 
   file { '/etc/ssh/sshd_config':
-    ensure     => present,
+    ensure     => file,
     source     => 'puppet:///modules/sshd/sshd_config',
     require    => Package['openssh-server'],
   }

--- a/quests/variables_and_parameters.md
+++ b/quests/variables_and_parameters.md
@@ -128,12 +128,12 @@ class web {
   $french = 'Bonjour le monde!'
 
   file { "${doc_root}hello.html":
-    ensure => present,
+    ensure => file,
     content => "<em>${english}</em>",
   }
   
   file { "${doc_root}bonjour.html":
-    ensure => present,
+    ensure => file,
     content => "<em>${french}</em>",
   }
 
@@ -213,7 +213,7 @@ parameters:
 
 ```puppet
 file { "${doc_root}${page_name}.html":
-  ensure => present,
+  ensure => file,
   content => "<em>${message}</em>",
 }
 ```

--- a/tests/test_tests/modules.sh
+++ b/tests/test_tests/modules.sh
@@ -17,7 +17,7 @@ echo "set number" >> vimrc/files/vimrc
 cat << EOL > vimrc/manifests/init.pp
 class vimrc {
   file { '/root/.vimrc':
-    ensure => present,
+    ensure => file,
     source => 'puppet:///modules/vimrc/vimrc',
   }
 }

--- a/tests/test_tests/resource_ordering.sh
+++ b/tests/test_tests/resource_ordering.sh
@@ -55,7 +55,7 @@ class sshd {
   }
 
   file { '/etc/ssh/sshd_config':
-    ensure     => present,
+    ensure     => file,
     source     => 'puppet:///modules/sshd/sshd_config',
     require    => Package['openssh-server'],
   }
@@ -79,7 +79,7 @@ class sshd {
   }
 
   file { '/etc/ssh/sshd_config':
-    ensure     => present,
+    ensure     => file,
     source     => 'puppet:///modules/sshd/sshd_config',
     require    => Package['openssh-server'],
   }

--- a/tests/test_tests/variables_and_parameters.sh
+++ b/tests/test_tests/variables_and_parameters.sh
@@ -13,12 +13,12 @@ class web {
   $french = 'Bonjour le monde!'
 
   file { "${doc_root}hello.html":
-    ensure => present,
+    ensure => file,
     content => "<em>${english}</em>",
   }
 
   file { "${doc_root}bonjour.html":
-    ensure => present,
+    ensure => file,
     content => "<em>${french}</em>",
   }
 
@@ -38,17 +38,17 @@ class web ( $page_name, $message ) {
   $french = 'Bonjour le monde!'
 
   file { "${doc_root}hello.html":
-    ensure => present,
+    ensure => file,
     content => "<em>${english}</em>",
   }
 
   file { "${doc_root}bonjour.html":
-    ensure => present,
+    ensure => file,
     content => "<em>${french}</em>",
   }
 
   file { "${doc_root}${page_name}.html":
-    ensure => present,
+    ensure => file,
     content => "<em>${message}</em>",
   }
 


### PR DESCRIPTION
While `ensure => present` is perfectly valid, best practices dictate
we not use it, as Linux sees both files and directories as files on
a block device. Consequently, `ensure => file` is more appropriate.

Additionally, we want to get users in the habit of doing this in
their code, as to not cause potential errors or security risks in
the future.