### PR TITLE
Standardize coding practices

### DIFF
--- a/quests/application_orchestrator.md
+++ b/quests/application_orchestrator.md
@@ -459,11 +459,11 @@ define lamp::webapp (
 
   $indexphp = @("EOT"/)
     <?php
-    \$conn = mysql_connect('$db_host', '$db_user', '$db_password');
+    \$conn = mysql_connect('${db_host}', '${db_user}', '${db_password}');
     if (!\$conn) {
-      echo "Connection to $db_host as $db_user failed";
+      echo 'Connection to ${db_host} as ${db_user failed}';
     } else {
-      echo "Connected successfully to $db_host as $db_user";
+      echo 'Connected successfully to ${db_host} as ${db_user}';
     }
     ?>
     | EOT

--- a/quests/defined_resource_types.md
+++ b/quests/defined_resource_types.md
@@ -95,7 +95,7 @@ define web_user::user {
     ensure  => directory,
     owner   => $title,
     group   => $title,
-    mode    => '0755',
+    mode    => '0775',
   }
 } 
 ```
@@ -238,7 +238,7 @@ define web_user::user {
     ensure  => directory,
     owner   => $title,
     group   => $title,
-    mode    => '0755',
+    mode    => '0775',
   }
   file { "${public_html}/index.html":
     ensure  => file,
@@ -246,7 +246,7 @@ define web_user::user {
     group   => $title,
     replace => false,
     content => "<h1>Welcome to ${title}'s home page!</h1>",
-    mode    => '0644',
+    mode    => '0664',
   }
 }
 ```
@@ -322,7 +322,7 @@ define web_user::user (
     ensure => directory,
     owner  => $title,
     group  => $title,
-    mode    => '0755',
+    mode    => '0775',
   }
   file { "${public_html}/index.html":
     ensure  => file,
@@ -330,7 +330,7 @@ define web_user::user (
     group   => $title,
     replace => false,
     content => $content,
-    mode    => '0644',
+    mode    => '0664',
   }
 }
 ```

--- a/quests/variables_and_parameters.md
+++ b/quests/variables_and_parameters.md
@@ -67,7 +67,7 @@ For instance, if you wanted Puppet to manage several files in the `/var/www/ques
 directory, you could assign this directory path to a variable:
 
 ```puppet
-$doc_root = '/var/www/quest/'
+$doc_root = '/var/www/quest'
 ```
 
 Once the variable is set, you can avoid repeating the same directory path by
@@ -76,10 +76,10 @@ inserting the `$doc_root` variable into the beginning of any string.
 For example, you might use it in the title of a few *file* resource declarations:
 
 ```puppet
-file { "${doc_root}index.html":
+file { "${doc_root}/index.html":
   ...
 }
-file { "${doc_root}about.html":
+file { "${doc_root}/about.html":
   ...
 }
 ```
@@ -122,17 +122,17 @@ And then add the following contents (remember to use `:set paste` in vim):
 ```puppet
 class web {
 
-  $doc_root = '/var/www/quest/'
+  $doc_root = '/var/www/quest'
   
   $english = 'Hello world!'
   $french = 'Bonjour le monde!'
 
-  file { "${doc_root}hello.html":
+  file { "${doc_root}/hello.html":
     ensure => present,
     content => "<em>${english}</em>",
   }
   
-  file { "${doc_root}bonjour.html":
+  file { "${doc_root}/bonjour.html":
     ensure => present,
     content => "<em>${french}</em>",
   }
@@ -212,7 +212,7 @@ Now create a third file resource declaration to use the variables set by your
 parameters:
 
 ```puppet
-file { "${doc_root}${page_name}.html":
+file { "${doc_root}/${page_name}.html":
   ensure => present,
   content => "<em>${message}</em>",
 }

--- a/tests/test_tests/defined_resource_types.sh
+++ b/tests/test_tests/defined_resource_types.sh
@@ -15,7 +15,7 @@ define web_user::user {
     ensure  => directory,
     owner   => $title,
     group   => $title,
-    mode    => '0755',
+    mode    => '0775',
   }
 }
 EOL
@@ -37,7 +37,7 @@ define web_user::user {
     ensure  => directory,
     owner   => $title,
     group   => $title,
-    mode    => '0755',
+    mode    => '0775',
   }
   file { "${public_html}/index.html":
     ensure  => file,
@@ -45,7 +45,7 @@ define web_user::user {
     group   => $title,
     replace => false,
     content => "<h1>Welcome to ${title}'s home page!</h1>",
-    mode    => '0644',
+    mode    => '0664',
   }
 }
 EOL
@@ -66,7 +66,7 @@ cat << "EOL" > web_user/manifests/user.pp
     ensure  => directory,
     owner   => $title,
     group   => $title,
-    mode    => '0755',
+    mode    => '0775',
   }
   file { "${public_html}/index.html":
     ensure  => file,
@@ -74,7 +74,7 @@ cat << "EOL" > web_user/manifests/user.pp
     group   => $title,
     replace => false,
     content => "<h1>Welcome to ${title}'s home page!</h1>",
-    mode    => '0644',
+    mode    => '0664',
   }
 }
 EOL

--- a/tests/test_tests/variables_and_parameters.sh
+++ b/tests/test_tests/variables_and_parameters.sh
@@ -7,17 +7,17 @@ mkdir -p web/{manifests,examples}
 cat << "EOL" > web/manifests/init.pp
 class web {
 
-   $doc_root = '/var/www/quest/'
+   $doc_root = '/var/www/quest'
 
   $english = 'Hello world!'
   $french = 'Bonjour le monde!'
 
-  file { "${doc_root}hello.html":
+  file { "${doc_root}/hello.html":
     ensure => present,
     content => "<em>${english}</em>",
   }
 
-  file { "${doc_root}bonjour.html":
+  file { "${doc_root}/bonjour.html":
     ensure => present,
     content => "<em>${french}</em>",
   }
@@ -32,22 +32,22 @@ puppet apply web/examples/init.pp
 cat << "EOL" > web/manifests/init.pp
 class web ( $page_name, $message ) {
 
-  $doc_root = '/var/www/quest/'
+  $doc_root = '/var/www/quest'
 
   $english = 'Hello world!'
   $french = 'Bonjour le monde!'
 
-  file { "${doc_root}hello.html":
+  file { "${doc_root}/hello.html":
     ensure => present,
     content => "<em>${english}</em>",
   }
 
-  file { "${doc_root}bonjour.html":
+  file { "${doc_root}/bonjour.html":
     ensure => present,
     content => "<em>${french}</em>",
   }
 
-  file { "${doc_root}${page_name}.html":
+  file { "${doc_root}/${page_name}.html":
     ensure => present,
     content => "<em>${message}</em>",
   }

--- a/tests/variables_and_parameters_spec.rb
+++ b/tests/variables_and_parameters_spec.rb
@@ -28,7 +28,9 @@ end
 describe "Task 5:" do
   it 'Add $page_name and $message parameters and create a file using their values' do
     file("#{MODULE_PATH}web/manifests/init.pp").content.should match /class\s+web\s+\(\s*(\$page_name|\$message),\s+(\$page_name|\$message)\s*\)/
-    file("#{MODULE_PATH}web/manifests/init.pp").content.should match /file\s+\{\s+\"\$\{doc_root\}\$\{page_name\}\.html\":/
+    file("#{MODULE_PATH}web/manifests/init.pp")
+      .content
+      .should match /file\s*\{\s*\"\$\{doc_root\}\/?\$\{page_name\}\.html\"\s*:/
   end
 end
 


### PR DESCRIPTION
This commit standardizes the following:
- Setting the group write bit by default for `file` resources
- Not using trailing slashes in variable instantiations to better support parameters
- Proper use of string and variable interpolations in heredocs

In many cases, this is just bringing the effected files into conformance with other files
in the repository. In the cases where this affected tests or harness files, those were
appropriately updated, as well.