### PR TITLE
update pe_repo class to match operating system of docker image

### DIFF
--- a/quests/agent_setup.md
+++ b/quests/agent_setup.md
@@ -125,7 +125,7 @@ following credentials to connect to the console:
 * password: **puppetlabs**
 
 In the **Nodes** > **Classification** section, click on the **PE Master** node
-group. Under the **Classes** tab, enter `pe_repo::platform::ubuntu_1404_amd64`.
+group. Under the **Classes** tab, enter `pe_repo::platform::ubuntu_1604_amd64`.
 Click the **Add class** button and commit the change.
 
 Trigger a Puppet agent run on your Puppet master.


### PR DESCRIPTION
Resolves this error when trying to run the quest as specified due to an updated version of Ubuntu in the docker image:

`The agent packages needed to support ubuntu-16.04-amd64 are not present on your master.     To add them, apply the pe_repo::platform::ubuntu_1604_amd64 class to your master node and then run P
uppet.     The required agent packages should be retrieved when puppet runs on the master, after which you can run the install.bash script again.`
