### PR TITLE
Updated email link in agent-setup

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -45,6 +45,6 @@ in the PE stack to fully start after the VM boots. Once you're connected to the
 VM, we suggest updating the clock with `ntpdate pool.ntp.org`.
 
 1. You can access this Quest Guide via a webserver running on the Learning VM
-itself. Open a web broswer on your host and enter the Learning VM's IP address
+itself. Open a web browser on your host and enter the Learning VM's IP address
 in the address bar. (Be sure to use `http://<ADDRESS>` for the Quest Guide, as
 `https://<ADDRESS>` will take you to the PE console.)

--- a/quests/agent_setup.md
+++ b/quests/agent_setup.md
@@ -28,7 +28,7 @@ require a working internet connection. Our goal is to give you a
 lightweight environment where you can learn how Puppet works in a multi-node
 environment, but we achieve this at a certain cost to stability. We apologize
 for any issues that come up as we continue to iterate on this system. Feel free
-to contact us at [learningvm@puppet.com](mailto:learningvm@puppet.com).
+to contact us at learningvm@puppetlabs.com.
 
 When you're ready to get started, type the following command:
 

--- a/quests/agent_setup.md
+++ b/quests/agent_setup.md
@@ -28,7 +28,7 @@ require a working internet connection. Our goal is to give you a
 lightweight environment where you can learn how Puppet works in a multi-node
 environment, but we achieve this at a certain cost to stability. We apologize
 for any issues that come up as we continue to iterate on this system. Feel free
-to contact us at learningvm@puppetlabs.com.
+to contact us at [learningvm@puppet.com](mailto:learningvm@puppet.com).
 
 When you're ready to get started, type the following command:
 

--- a/quests/power_of_puppet.md
+++ b/quests/power_of_puppet.md
@@ -186,7 +186,7 @@ typing, the `graphite` class should autofill. If it does not, click the
 *Refresh* button near the top right of the classes interface and wait a moment
 before trying again. (If the class still does not appear, check the
 [troubleshooting
-guide](../troubleshooting.html)
+guide](https://github.com/puppetlabs/courseware-lvm/blob/master/SETUP.md#troubleshooting)
 for more information.)
 
 Once you have entered `graphite` in the *Class name* text box, click the *Add class* button.

--- a/quests/power_of_puppet.md
+++ b/quests/power_of_puppet.md
@@ -186,7 +186,7 @@ typing, the `graphite` class should autofill. If it does not, click the
 *Refresh* button near the top right of the classes interface and wait a moment
 before trying again. (If the class still does not appear, check the
 [troubleshooting
-guide](https://github.com/puppetlabs/courseware-lvm/blob/master/SETUP.md#troubleshooting)
+guide](../troubleshooting.html)
 for more information.)
 
 Once you have entered `graphite` in the *Class name* text box, click the *Add class* button.


### PR DESCRIPTION
It looks like the email listed in agent-setup is the older @puppetlabs.com format, so I found an email link in the afterword and copied the format there (assuming it's how you'd now want to encode the email link).  Hope this helps!