### PR TITLE
Link to learning vm

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -45,6 +45,6 @@ in the PE stack to fully start after the VM boots. Once you're connected to the
 VM, we suggest updating the clock with `ntpdate pool.ntp.org`.
 
 1. You can access this Quest Guide via a webserver running on the Learning VM
-itself. Open a web broswer on your host and enter the Learning VM's IP address
+itself. Open a web browser on your host and enter the Learning VM's IP address
 in the address bar. (Be sure to use `http://<ADDRESS>` for the Quest Guide, as
 `https://<ADDRESS>` will take you to the PE console.)

--- a/quests/agent_setup.md
+++ b/quests/agent_setup.md
@@ -28,7 +28,7 @@ require a working internet connection. Our goal is to give you a
 lightweight environment where you can learn how Puppet works in a multi-node
 environment, but we achieve this at a certain cost to stability. We apologize
 for any issues that come up as we continue to iterate on this system. Feel free
-to contact us at [learningvm@puppet.com](mailto:learningvm@puppet.com).
+to contact us at learningvm@puppetlabs.com.
 
 When you're ready to get started, type the following command:
 

--- a/quests/agent_setup.md
+++ b/quests/agent_setup.md
@@ -28,7 +28,7 @@ require a working internet connection. Our goal is to give you a
 lightweight environment where you can learn how Puppet works in a multi-node
 environment, but we achieve this at a certain cost to stability. We apologize
 for any issues that come up as we continue to iterate on this system. Feel free
-to contact us at learningvm@puppetlabs.com.
+to contact us at [learningvm@puppet.com](mailto:learningvm@puppet.com).
 
 When you're ready to get started, type the following command:
 

--- a/quests/power_of_puppet.md
+++ b/quests/power_of_puppet.md
@@ -186,7 +186,7 @@ typing, the `graphite` class should autofill. If it does not, click the
 *Refresh* button near the top right of the classes interface and wait a moment
 before trying again. (If the class still does not appear, check the
 [troubleshooting
-guide](../troubleshooting.html)
+guide](https://github.com/puppetlabs/courseware-lvm/blob/master/SETUP.md#troubleshooting)
 for more information.)
 
 Once you have entered `graphite` in the *Class name* text box, click the *Add class* button.

--- a/quests/power_of_puppet.md
+++ b/quests/power_of_puppet.md
@@ -186,7 +186,7 @@ typing, the `graphite` class should autofill. If it does not, click the
 *Refresh* button near the top right of the classes interface and wait a moment
 before trying again. (If the class still does not appear, check the
 [troubleshooting
-guide](https://github.com/puppetlabs/courseware-lvm/blob/master/SETUP.md#troubleshooting)
+guide](../troubleshooting.html)
 for more information.)
 
 Once you have entered `graphite` in the *Class name* text box, click the *Add class* button.


### PR DESCRIPTION
I noticed that the troubleshooting link points to an old repo marked "defunct".  When I thought about what the best substitute was, I recall noticing how much effort has gone into making the Learning VM "offline-friendly" - e.g. even if there are network issues that would harm access to the Puppet Forge, the Learning VM includes the modules in an offline cache *and* instructions on how to slipstream the modules to keep the quests moving smoothly.

It's a judgment call and I won't pretend to know more about the overall design philosophy of the Learning VM than you folks, but I took a guess that it would be better to point to the copy of the troubleshooting guide that's cached locally in the Learning VM than to point to the possibly-more-up-to-date but still remote copy in the current repo.