### PR TITLE
Update mysql.md account security  task

### DIFF
--- a/quests/mysql.md
+++ b/quests/mysql.md
@@ -173,7 +173,7 @@ mentioned above does just this.
 <div class = "lvm-task-number"><p>Task 4:</p></div>
 
 Go back to your `site.pp` manifest and include the `mysql::server::account_security`
-class in the `learning.puppetlabs.vm` node (after the class definition for ::mysql::server). 
+class in the `learning.puppetlabs.vm` node after the class definition for `::mysql::server`. 
 Remember, you don't need to pass any
 parameters to this class, so a simple `include` statement will work in place
 of a parameterized class declaration.

--- a/quests/mysql.md
+++ b/quests/mysql.md
@@ -173,12 +173,14 @@ mentioned above does just this.
 <div class = "lvm-task-number"><p>Task 4:</p></div>
 
 Go back to your `site.pp` manifest and include the `mysql::server::account_security`
-class in the `learning.puppetlabs.vm` node. Remember, you don't need to pass any
+class in the `learning.puppetlabs.vm` node (after the class definition for ::mysql::server). 
+Remember, you don't need to pass any
 parameters to this class, so a simple `include` statement will work in place
 of a parameterized class declaration.
 
 ```puppet
 node 'learning.puppetlabs.vm' {
+  ...
   include ::mysql::server::account_security
   ...
 }

--- a/quests/mysql.md
+++ b/quests/mysql.md
@@ -173,7 +173,7 @@ mentioned above does just this.
 <div class = "lvm-task-number"><p>Task 4:</p></div>
 
 Go back to your `site.pp` manifest and include the `mysql::server::account_security`
-class in the `learning.puppetlabs.vm` node after the class definition for `::mysql::server`. 
+class in the `learning.puppetlabs.vm` node after the class declaration for `::mysql::server`. 
 Remember, you don't need to pass any
 parameters to this class, so a simple `include` statement will work in place
 of a parameterized class declaration.


### PR DESCRIPTION
The account security task is a bit ambiguously stated:

"Go back to your site.pp manifest and include the mysql::server::account_security class in the learning.puppetlabs.vm node. Remember, you don't need to pass any parameters to this class, so a simple include statement will work ***in place of a parameterized class declaration.***"

My initial read of this was that the ::mysql::server::account_security would auto-require the ::mysql::server class, so I should  replace the class definition with the include directive.  This of course leads to an error.

Adding the suggested phrasing would make it clear that the "include ::mysql::server::account_security" should come after the ::mysql::server class definition.