### PR TITLE
Revert "remove ubuntu agent step, as this is done at build time"

### DIFF
--- a/quests/agent_setup.md
+++ b/quests/agent_setup.md
@@ -113,6 +113,29 @@ our Puppet infrastructure.
 
 <div class = "lvm-task-number"><p>Task 3:</p></div>
 
+In most cases, the simplest way to install an agent is to use the `curl`
+command to transfer an installation script from your Puppet master and
+execute it. Because our agents are running an Ubuntu system, we'll first
+need to make sure that our Puppet master has the correct script to provide.
+
+Navigate to `https://<VM's IP address>` in your browser address bar. Use the
+following credentials to connect to the console:
+
+* username: **admin**
+* password: **puppetlabs**
+
+In the **Nodes** > **Classification** section, click on the **PE
+Infrastructure** section and select the **PE Master** node group. Under the
+**Classes** tab, enter `pe_repo::platform::ubuntu_1404_amd64`.  Click the **Add
+class** button and commit the change.
+
+Trigger a Puppet agent run on your Puppet master.
+
+    puppet agent -t
+
+
+<div class = "lvm-task-number"><p>Task 4:</p></div>
+
 Ordinarily, you would probably use `ssh` to connect to your agent nodes and
 run this command. Because we're using docker, however, the way we connect will
 be a little different. To connect to your `webserver` node, run the following
@@ -154,7 +177,7 @@ We can also see that this node's fqdn is `database.learning.puppetlabs.vm`. This
 is how we can identify the node in the PE console or the `site.pp` manifest on
 our master.
 
-<div class = "lvm-task-number"><p>Task 4:</p></div>
+<div class = "lvm-task-number"><p>Task 5:</p></div>
 
 We can use the Puppet resource tool to easily create a new test file on your
 database node. Still connected to that system, run the following command:
@@ -228,7 +251,7 @@ on the Puppet master. If you're still connected to your agent node, return to th
 
     exit
 
-<div class = "lvm-task-number"><p>Task 5:</p></div>
+<div class = "lvm-task-number"><p>Task 6:</p></div>
 
 Use the `puppet cert list` command to list the unsigned certificates. (You can
 also view and sign these from the inventory page of the PE console.)

--- a/tests/agent_setup_spec.rb
+++ b/tests/agent_setup_spec.rb
@@ -13,6 +13,13 @@ describe "Task 2:" do
 end
 
 describe "Task 3:" do
+  it "Prepare your puppet master to provide the ubuntu agent installer" do
+    file("/opt/puppetlabs/server/data/packages/public/current/ubuntu-14.04-amd64")
+      .should be_symlink
+  end
+end
+
+describe "Task 4:" do
   it "Install the Puppet agent on your database and webserver nodes" do
     command('docker exec webserver puppet')
       .stdout
@@ -23,7 +30,7 @@ describe "Task 3:" do
   end
 end
 
-describe "Task 4:" do
+describe "Task 5:" do
   it "Use the puppet resourse file to create a test file on your agent node" do
     command('docker exec database ls /tmp/test')
       .exit_status
@@ -31,7 +38,7 @@ describe "Task 4:" do
   end
 end
 
-describe "Task 5:" do
+describe "Task 6:" do
   it "Sign the certs for your new nodes" do
     file('/etc/puppetlabs/puppet/ssl/ca/signed/database.learning.puppetlabs.vm.pem')
       .should be_file
@@ -40,7 +47,7 @@ describe "Task 5:" do
   end
 end
 
-describe "Task 6:" do
+describe "Task 7:" do
   it "Create a notify resource in your default node group" do
     file("#{PROD_PATH}manifests/site.pp")
       .content

--- a/tests/test_tests/agent_setup.sh
+++ b/tests/test_tests/agent_setup.sh
@@ -11,15 +11,18 @@ EOL
 #Task 2
 puppet agent -t
 #Task 3
+curl -i -k --cacert /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem --key /etc/puppetlabs/puppet/ssl/private_keys/learning.puppetlabs.vm.pem --cert /etc/puppetlabs/puppet/ssl/certs/learning.puppetlabs.vm.pem -H "Content-Type: application/json" -X POST -d '{"classes":{"pe_repo::platform::ubuntu_1404_amd64":{}}}' https://localhost:4433/classifier-api/v1/groups/2f587cb3-f961-4ad2-86aa-6abcbdc17843
+puppet agent -t
+#Task 4
 docker exec -it webserver sh -c "curl -k https://learning.puppetlabs.vm:8140/packages/current/install.bash | sudo bash"
 docker exec -it database sh -c "curl -k https://learning.puppetlabs.vm:8140/packages/current/install.bash | sudo bash"
-#Task 4
+#Task 5
 docker exec -it database sh -c "puppet resource file /tmp/test ensure=file"
 docker exec -it database sh -c "puppet apply /tmp/test.pp"
-#Task 5
+#Task 6
 puppet cert sign webserver.learning.puppetlabs.vm
 puppet cert sign database.learning.puppetlabs.vm
-#Task 6
+#Task 1
 cat << "EOL" > /etc/puppetlabs/code/environments/production/manifests/site.pp
 File { backup => false }
 node 'learning.puppetlabs.vm' {


### PR DESCRIPTION
Reverts puppetlabs/puppet-quest-guide#103
Turns out this is still necessary.