### PR TITLE
Edit review of the setup steps

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -2,49 +2,39 @@
 
 # Set up the Learning VM
 
-1. Before beginning, you may want to use the MD5 sum provided at the VM
-download page to verify your download. On Mac OS X and *nix systems, you can
-use the command `md5 learning_puppet_vm.zip` and compare the output to the text
-contents of the `learning_puppet_vm.zip.md5` file provided on the download
-page. On Windows systems, you will need to download and use a tool such as the
-[Microsoft File Checksum Integrity Verifier](https://www.microsoft.com/en-us/download/details.aspx?id=11533).
-
-1. Get an up-to-date version of your virtualization software. We suggest using
+1. Ensure you have an up-to-date version of virtualization software installed. We suggest using
 either VirtualBox or a VMware application appropriate for your platform.
 [VirtualBox](https://www.virtualbox.org/wiki/Downloads) is free and available
 for Linux, OS X, and Windows. VMware has several desktop virtualization
-applications, including [VMWare
+applications, including [VMware
 Fusion](https://www.vmware.com/products/fusion/) for Mac and [VMware
 Workstation](https://www.vmware.com/products/workstation/) for Windows.
 
 1. The Learning VM's Open Virtualization Archive format must be *imported*
 rather than opened directly. Launch your virtualization software and find an
-option for *Import* or *Import Appliance*. (This will usually be in a *File*
-menu. If you cannot locate an *Import* option, please refer to your
-virtualization software's documentation.)
+option for **Import** or **Import Appliance**. This will usually be in a **File**
+menu. If you cannot locate an **Import** option, refer to your
+virtualization software's documentation.
 
-1. *Before* starting the VM for the first time, you will need to adjust its
-settings.  We recommend allocating 4GB of memory for the best performance. If
-you don't have enough memory on your host machine, you may leave the allocation
-at 3GB or lower it to 2GB, though you may encounter stability and performance
-issues. Set the *Network Adapter* to *Bridged*. Use an *Autodetect* setting if
-available, or accept the default Network Adapter name. (If you started the VM
-before making these changes, you may need to restart the VM before the settings
-will be applied correctly.) If you are unable to use a bridged network, we
-suggest using the port-forwarding instructions provided in the troubleshooting
-guide.
+1. *Before* starting the VM for the first time, adjust its
+settings.  Allocate 4GB of memory for the best performance. If
+you don't have enough memory on your host machine, you can leave the allocation
+at 3GB or lower it to 2GB, but you might encounter stability and performance
+issues. Set the **Network Adapter** to **Bridged**. Use an autodetect setting if
+available, or accept the default network adapter name. If you are unable to use 
+a bridged network, use the port-forwarding instructions provided in the Troubleshooting
+chapter.
 
-1. Start the VM. When it is started, make a note of the IP address and password
-displayed on the splash page. Rather than logging in directly, we highly
-recommend using SSH. On OS X, you can use the default Terminal application or a
-third-party application like iTerm.  For Windows, we suggest the free SSH
-client [PuTTY](http://www.putty.org/).  Connect to the Learning VM with the
-login `root` and password you noted from the splash page.  (e.g. `ssh
-root@<IPADDRESS>`) Be aware that it might take several minutes for the services
-in the PE stack to fully start after the VM boots. Once you're connected to the
-VM, we suggest updating the clock with `ntpdate pool.ntp.org`.
+1. Start the VM. Write down the IP address and password
+displayed on the splash page. Rather than logging in directly, use SSH. On 
+OS X, use the default Terminal application or an
+application like iTerm.  For Windows, we suggest the free SSH
+client [PuTTY](http://www.putty.org/).  Connect to the Learning VM  by running: `ssh
+root@<IPADDRESS>` and use the login `root` and password you noted from the splash 
+page. It can take several minutes for the services
+in the Puppet Enterprise stack to fully start. Once you're connected to the
+VM, update the clock by running `ntpdate pool.ntp.org`.
 
-1. You can access this Quest Guide via a webserver running on the Learning VM
-itself. Open a web broswer on your host and enter the Learning VM's IP address
-in the address bar. (Be sure to use `http://<ADDRESS>` for the Quest Guide, as
-`https://<ADDRESS>` will take you to the PE console.)
+1. Access this Quest Guide by opening a web browser on your host and entering
+the Learning VM's IP address in the address bar. Use `http://<ADDRESS>`, not `https`, which
+will open the PE console.

--- a/SETUP.md
+++ b/SETUP.md
@@ -19,7 +19,7 @@ virtualization software's documentation.
 1. *Before* starting the VM for the first time, adjust its
 settings.  Allocate 4GB of memory for the best performance. If
 you don't have enough memory on your host machine, you can leave the allocation
-at 3GB or lower it to 2GB, but you might encounter stability and performance
+at 3GB, but you might encounter stability and performance
 issues. Set the **Network Adapter** to **Bridged**. Use an autodetect setting if
 available, or accept the default network adapter name. If you are unable to use 
 a bridged network, use the port-forwarding instructions provided in the Troubleshooting


### PR DESCRIPTION
I removed the step about MD5 sum because ... if they are looking at this, they successfully unzipped the download, right? The MD5 instructions are on the download page already, and it made for a very unfriendly first step to document "Your download maybe failed, here's a utility to run." If you need to add it back in, maybe add it at the point where they'll fail (when they try to import the OVA?) as a Note, rather than a step.

The step that starts with "Start the VM" is very long, and seems to contain many steps. Are they in the right order? Do we want people running ssh at this point? Or do we just want them to have installed iTerm or PuTTY? If they shouldn't be running ssh right NOW, while the VM is starting, then delete the sentence that tells them to do it. Or move it till after the "It can take several minutes" sentence? I'm not sure.