### PR TITLE
Removed defaults from the pasture_config.yaml.epp template

### DIFF
--- a/quests/conditional_statements.md
+++ b/quests/conditional_statements.md
@@ -190,10 +190,10 @@ template with the same `webrick` default. The Pasture appication passes any
 settings under the `:sinatra_settings:` key to Sinatra itself.
 
 ```yaml
-<%- | $port              = '80',
-      $default_character = 'sheep',
-      $default_message   = '',
-      $sinatra_server    = 'webrick',
+<%- | $port,
+      $default_character,
+      $default_message,
+      $sinatra_server,
 | -%>
 # This file is managed by Puppet. Please do not make manual changes.
 ---

--- a/quests/conditional_statements.md
+++ b/quests/conditional_statements.md
@@ -186,8 +186,8 @@ Once that's complete, open the `pasture_config.yaml.epp` template.
     vim pasture/templates/pasture_config.yaml.epp
 
 Add the `$sinatra_server` variable to the params block at the beginning of the
-template with the same `webrick` default. The Pasture appication passes any
-settings under the `:sinatra_settings:` key to Sinatra itself.
+template. The Pasture appication passes any settings under the
+`:sinatra_settings:` key to Sinatra itself.
 
 ```yaml
 <%- | $port,

--- a/quests/package_file_service.md
+++ b/quests/package_file_service.md
@@ -167,7 +167,7 @@ Include a line here to set the default character to `elephant`.
 
 ```yaml
 ---
-  :default_character: elephant
+:default_character: elephant
 ```
 
 With this source file saved to your module's `files` directory, you can use

--- a/quests/variables_and_templates.md
+++ b/quests/variables_and_templates.md
@@ -170,8 +170,8 @@ The beginning of your template should look like the following. We'll explain
 the details of the syntax below.
 
 ```
-<%- | $port              = '80',
-      $default_character = 'sheep',
+<%- | $port,
+      $default_character,
 | -%>
 # This file is managed by Puppet. Please do not make manual changes.
 ```
@@ -188,9 +188,9 @@ Next, we'll use the variables we set up to define values for the port and
 character configuration options.
 
 ```
-<%- | $port              = '80',
-      $default_character = 'sheep',
-      $default_message   = '',
+<%- | $port,
+      $default_character,
+      $default_message,
 | -%>
 # This file is managed by Puppet. Please do not make manual changes.
 ---
@@ -240,6 +240,7 @@ class pasture {
 
   $port                = '80'
   $default_character   = 'sheep'
+  $default_message     = ''
   $pasture_config_file = '/etc/pasture_config.yaml'
 
   package {'pasture':
@@ -251,6 +252,7 @@ class pasture {
   $pasture_config_hash = {
     'port'              => $port,
     'default_character' => $default_character,
+    'default_message'   => $default_message,
   }
 
   file { $pasture_config_file:
@@ -263,7 +265,7 @@ class pasture {
     notify  => Service['pasture'],
   }
 
-  servive { 'pasture':
+  service { 'pasture':
     ensure    => running.
   }
 

--- a/tests/package_file_service_spec.rb
+++ b/tests/package_file_service_spec.rb
@@ -69,7 +69,7 @@ describe "Task 8:", host: :localhost do
       .should be_file
     file("#{MODULE_PATH}pasture/files/pasture_config.yaml")
       .content
-      .should match /^---.*?\s\s:default_character:\s+elephant/m
+      .should match /^---.*?:default_character:\s+elephant/m
   end
 end
 


### PR DESCRIPTION
The default values are set in the enclosing class, so removed them from the pasture_config.yaml.epp file to keep things simple