### PR TITLE
Clear cert from /etc/docker/ssl_dir on reset

### DIFF
--- a/tests/scripts/clear_nodes.pp
+++ b/tests/scripts/clear_nodes.pp
@@ -2,5 +2,6 @@ $facts['docker_hosts'].each |$name, $ip| {
   service { "docker-${name}.service":
     ensure => stopped,
   }
+  exec { "/bin/find /etc/docker/ssl_dir -name ${name}.pem -delete": }
   exec { "/opt/puppetlabs/bin/puppet cert clean ${name}": }
 }


### PR DESCRIPTION
The .pem files must be cleared from the mounted
/etc/docker/ssl_dir/ directory to prevent SSL errors
when attempting a puppet run after a node with the same
hostname has been re-created.