### PR TITLE
(LEARNVM-509) Web Terminal for LVM

### DIFF
--- a/_layouts/website/page.html
+++ b/_layouts/website/page.html
@@ -1,0 +1,14 @@
+{% extends template.self %}
+
+{% block body %}
+    {{ super() }}
+
+    <div class="terminal_wrapper">
+        <iframe id="terminal" src=""></iframe>
+    </div>
+
+    <script>
+        document.getElementById("terminal").setAttribute("src", "http://" + window.location.hostname.toString() + ":9091");
+    </script>
+
+{% endblock %}

--- a/styles/website.css
+++ b/styles/website.css
@@ -14,6 +14,33 @@
   src: url('/gitbook/fonts/calibre/CalibreWeb-Semibold.woff');
 }
 
+/* Terminal pinning */
+body {
+  display: flex;
+}
+
+.book {
+  flex: 1;
+}
+
+.terminal_wrapper {
+  flex: 1;
+  min-width: 700px;
+  overflow: hidden;
+}
+
+#terminal {
+  height: 100%;
+  width: 100%;
+  border: none;
+}
+
+@media (max-width: 1400px) {
+  body {
+    flex-direction: column;
+  }
+}
+
 .book.font-family-1,
 .book .book-header,
 .book .book-summary {


### PR DESCRIPTION
LEARNVM-509 #resolved #time 5h
Added web terminal to the LVM through Gitbook theming and some
 CSS. It will show to the right until 1400px and then switch to
 underneath.  Overflow of the terminal is hidden to prevent two
 scrollbars.