### PR TITLE
Allow space between curly brace and package name

### DIFF
--- a/tests/variables_and_templates_spec.rb
+++ b/tests/variables_and_templates_spec.rb
@@ -2,7 +2,7 @@ describe "Task 1:", host: :localhost do
   it 'Add variables to the pasture main manifest' do
     file("#{MODULE_PATH}pasture/manifests/init.pp")
       .content
-      .should match /^class\s+pasture\s+{\s+\$port\s+=\s+(['"])80\1\s+\$default_character\s+=\s+(['"])sheep\2.*\s+\$default_message\s+=\s*(['"])\3\s+\$pasture_config_file\s+=\s+(['"])\/etc\/pasture_config\.yaml\4\s+package\s+{(['"])pasture\5:\s+.*before\s+=>\s+File\[\$pasture_config_file\],/m
+      .should match /^class\s+pasture\s+{\s+\$port\s+=\s+(['"])80\1\s+\$default_character\s+=\s+(['"])sheep\2.*\s+\$default_message\s+=\s*(['"])\3\s+\$pasture_config_file\s+=\s+(['"])\/etc\/pasture_config\.yaml\4\s+package\s+{\s+(['"])pasture\5:\s+.*before\s+=>\s+File\[\$pasture_config_file\],/m
     file("#{MODULE_PATH}pasture/manifests/init.pp")
       .content
       .should match /file\s+{\s+\$pasture_config_file:.*?notify\s+=>\s+Service\[(['"])pasture\1\],/m

--- a/tests/variables_and_templates_spec.rb
+++ b/tests/variables_and_templates_spec.rb
@@ -2,7 +2,7 @@ describe "Task 1:", host: :localhost do
   it 'Add variables to the pasture main manifest' do
     file("#{MODULE_PATH}pasture/manifests/init.pp")
       .content
-      .should match /^class\s+pasture\s+{\s+\$port\s+=\s+(['"])80\1\s+\$default_character\s+=\s+(['"])sheep\2.*\s+\$default_message\s+=\s*(['"])\3\s+\$pasture_config_file\s+=\s+(['"])\/etc\/pasture_config\.yaml\4\s+package\s+{\s+(['"])pasture\5:\s+.*before\s+=>\s+File\[\$pasture_config_file\],/m
+      .should match /^class\s+pasture\s+{\s+\$port\s+=\s+(['"])80\1\s+\$default_character\s+=\s+(['"])sheep\2.*\s+\$default_message\s+=\s*(['"])\3\s+\$pasture_config_file\s+=\s+(['"])\/etc\/pasture_config\.yaml\4\s+package\s+{\s*(['"])pasture\5:\s+.*before\s+=>\s+File\[\$pasture_config_file\],/m
     file("#{MODULE_PATH}pasture/manifests/init.pp")
       .content
       .should match /file\s+{\s+\$pasture_config_file:.*?notify\s+=>\s+Service\[(['"])pasture\1\],/m


### PR DESCRIPTION
In the preceding chapter, the quest suggests a space between the curly brace and the package name, like this:

> package { 'pasture':

But in the next exercise, you have to have no space there for the test to succeed:

> package {'pasture':

This change allows to have a space there, so that people who continue building their file from the previous exercise don't have to debug the quest.