### PR TITLE
(LEARNVM-610) Add explicit entry for README.md

### DIFF
--- a/us_en/summary.md
+++ b/us_en/summary.md
@@ -1,5 +1,6 @@
 # Summary
 
+* [Introduction](README.md)
 * [Setup](SETUP.md)
 
 ### Quests


### PR DESCRIPTION
Currently, the README.md is implicitly included and the name defaults to "Introduction." Adding an explicit entry for the README.md called "Introduction" allows the line to be picked up by the Transifex and properly translated into Japanese.