### PR TITLE
(LEARNVM-625) - Manually generate docker agent certs

### DIFF
--- a/tests/scripts/setup
+++ b/tests/scripts/setup
@@ -10,11 +10,10 @@ def create_node(name, image='agent', sign_cert=true, run_puppet=true)
   puts "Creating #{name}..."
   `puppet apply -e "dockeragent::node { '#{name}': ensure => present, image => '#{image}', require_dockeragent => false, }"`
   if sign_cert
-    wait_for_container(name)
-    `docker exec #{name} puppet agent -t`
-    sleep 3
-    `puppet cert sign --all`
-    sleep 3
+    `puppet cert generate #{name}`
+    `cp -f /etc/puppetlabs/puppet/ssl/certs/#{name}.pem /etc/docker/ssl_dir/`
+    `cp -f /etc/puppetlabs/puppet/ssl/public_keys/#{name}.pem /etc/docker/ssl_dir/public_keys/`
+    `cp -f /etc/puppetlabs/puppet/ssl/private_keys/#{name}.pem /etc/docker/ssl_dir/private_keys/`
   end
   if run_puppet
     `docker exec #{name} puppet agent -t`


### PR DESCRIPTION
The pltraining-dockeragent module mounts /etc/docker/ssl_dir onto
container nodes as /etc/puppetlabs/puppet/ssl. Because some node names
are shared across quests, the state of this directory isn't always
consistent. An initial puppet agent run may either create a CSR or
actually run puppet depending on whether a signed cert exists.

Doing the cert process manually ensures that the sign-cert step of
container agent provisioning will always only sign handle the cert
signing process, and never trigger a puppet run.