### PR TITLE
(LEARNVM-628) quest setup script improvements

### DIFF
--- a/tests/scripts/setup
+++ b/tests/scripts/setup
@@ -1,6 +1,7 @@
 #!/bin/ruby
 
 require 'socket'
+require 'erb'
 
 SCRIPT_DIR = File.dirname(__FILE__)
 
@@ -9,15 +10,20 @@ $stdout.sync = true
 def create_node(name, image='agent', sign_cert=true, run_puppet=true)
   puts "Creating #{name}..."
   `puppet apply -e "dockeragent::node { '#{name}': ensure => present, image => '#{image}', require_dockeragent => false, }"`
+  wait_for_container(name)
   if sign_cert
     `puppet cert generate #{name}`
-    sleep 3
+    sleep 2
     `cp -f /etc/puppetlabs/puppet/ssl/certs/#{name}.pem /etc/docker/ssl_dir/`
     `cp -f /etc/puppetlabs/puppet/ssl/public_keys/#{name}.pem /etc/docker/ssl_dir/public_keys/`
     `cp -f /etc/puppetlabs/puppet/ssl/private_keys/#{name}.pem /etc/docker/ssl_dir/private_keys/`
   end
-  if run_puppet
-    `docker exec #{name} puppet agent -t`
+end
+
+def run_puppet_on_nodes
+  docker_hosts.each do |name, ip|
+    #Use a bogus tag to only run pluginsync
+    `docker exec -d #{name} puppet agent -t --tags bogus`
   end
 end
 
@@ -29,88 +35,96 @@ def wait_for_container(name)
   end
 end
 
+def docker_hosts
+  hosts = {}
+  containers = `docker ps`.split("\n")
+  containers.shift
+  containers.each do |line|
+    name = line.split.last
+    hosts[name] = `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' #{name}`.chomp
+  end
+  return hosts
+end
+
 def clear_nodes
-  `puppet apply #{File.join(SCRIPT_DIR, 'clear_nodes.pp')}`
+  hosts = docker_hosts
+  hosts.each do |name, ip|
+    `systemctl stop docker-#{name}.service`
+    `/bin/find /etc/docker/ssl_dir -name #{name}.pem -delete`
+    `/opt/puppetlabs/bin/puppet cert clean #{name}`
+  end
 end
 
 def update_docker_hosts
+  hosts = docker_hosts
+  fqdn = `facter fqdn`.chomp
+hosts_template = <<-HEREDOC
+127.0.0.1 <%= fqdn %> learning localhost localhost.localdomain localhost4
+::2 localhost localhost.localdomain localhost6 localhost6.localdomain6
+<% hosts.each do |name, ip|  %>
+<%= $ip %> <%= $hostname %>\n
+<% end %>
+HEREDOC
   puts 'Updating /etc/hosts...'
-  `puppet apply #{File.join(SCRIPT_DIR, 'docker_hosts.pp')}`
+  File.write('/etc/hosts', ERB.new(hosts_template, 3, '>').result(binding))
 end
 
-def wait_for_ssh(hosts)
+def wait_for_ssh
   puts "Waiting for node SSH services to become available..."
-  hosts.each do |host|
+  docker_hosts.each do |name, ip|
     retries = 0
     begin
-      Socket.tcp(host, 22, connect_timeout: 5)
+      Socket.tcp(name, 22, connect_timeout: 5)
     rescue
       retries +=1
-      if retries > 5
+      if retries > 10
         puts "Timed out waiting for node SSH services to become available. Please refer the the Learning VM troubleshooting guide."
+        exit 1
       end
-      sleep 8
       retry
     end
   end
 end
 
 def node_setup(quest)
+  run_puppet_after = true
   case quest
   when 'hello_puppet'
     create_node('hello.puppet.vm', image='no_agent', sign_cert=false, run_puppet=false)
-    update_docker_hosts
-    wait_for_ssh(['hello.puppet.vm'])
+    run_puppet_after = false
   when 'agent_run'
     create_node('agent.puppet.vm', image='agent', sign_cert=false, run_puppet=false)
-    update_docker_hosts
-    wait_for_ssh(['agent.puppet.vm'])
+    run_puppet_after = false
   when 'manifests_and_classes'
     create_node('cowsay.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['cowsay.puppet.vm'])
   when 'package_file_service'
     create_node('pasture.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture.puppet.vm'])
   when 'variables_and_templates'
     create_node('pasture.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture.puppet.vm'])
   when 'class_parameters'
     create_node('pasture.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture.puppet.vm'])
   when 'facts'
     create_node('pasture.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture.puppet.vm'])
   when 'conditional_statements'
     create_node('pasture-dev.puppet.vm')
     create_node('pasture-prod.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture-dev.puppet.vm', 'pasture-prod.puppet.vm'])
   when 'the_forge'
     create_node('pasture-db.puppet.vm')
     create_node('pasture-app.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture-db.puppet.vm', 'pasture-app.puppet.vm'])
   when 'roles_and_profiles'
     create_node('pasture-app-small.puppet.vm')
     create_node('pasture-app-large.puppet.vm')
     create_node('pasture-db.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture-app-small.puppet.vm', 'pasture-app-large.puppet.vm', 'pasture-db.puppet.vm'])
   when 'defined_resource_types'
     create_node('pasture-app-small.puppet.vm')
     update_docker_hosts
-    wait_for_ssh(['pasture-app-small.puppet.vm'])
   when 'application_orchestrator'
     create_node('pasture-app-large.puppet.vm')
     create_node('pasture-db.puppet.vm')
-    update_docker_hosts
-    wait_for_ssh(['pasture-app-large.puppet.vm'])
   end
+  update_docker_hosts
+  run_puppet_on_nodes if run_puppet_after
+  wait_for_ssh
 end
 
 clear_nodes


### PR DESCRIPTION
When a containerized agent node is set up by the quest tool (via the
setup script) we need to handle certification so the user doesn't need
to repeat the cert signing process at the beginning of each quest. After
the initial quests where we demonstrate the full process of a puppet
agent run, including pluginsync, we want to pre-run pluginsync as a node
is created so the pluginsync output on their first manually triggered
puppet agent run will not be overwhelmed by the pluginsync output.

Prior to this PR, a full puppet run is triggered during node creation to
create a CSR, then another is triggered after the cert is signed to
handle pluginsync. However, this solution can lead to problems, as the
second puppet run will also generate a catalog and apply it to the node.
If the user has written code with an error, there may be issues with
this initial puppet run that they do not see because it is completed in
the background.

This PR addresses this issue by separating the cert signing process and
the initial puppet run into two distinct actions. The ssl files are
generated on the master and copied with cp to an ssl directory mounted
to the containers. This allows the certs to be handled outside the
context of a puppet agent run. The initial puppet agent run is then
triggered with a bogus `--tags bogus` parameter. This ensures that no
user-specified resources are actually applied on the node.

Note, however, that it is still possible that this initial run will fail
if there is a catalog compilation error.