### PR TITLE
(LEARNVM-630) Setup polling improvements

### DIFF
--- a/tests/application_orchestrator_spec.rb
+++ b/tests/application_orchestrator_spec.rb
@@ -155,6 +155,7 @@ end
 
 describe 'Task 8:', host: :localhost do
   it 'has a working solution', :solution do
+    wait_for_pxp_service
     command("puppet job run --application Pasture_app['pasture_01']")
       .exit_status
       .should_not eq 1

--- a/tests/conditional_statements_spec.rb
+++ b/tests/conditional_statements_spec.rb
@@ -78,6 +78,7 @@ end
 
 describe _("Task 5:"), host: :localhost do
   it 'has a working solution', :solution do
+    wait_for_pxp_service
     command("curl -i -k --cacert /etc/puppetlabs/puppet/ssl/ca/ca_crt.pem --key /etc/puppetlabs/puppet/ssl/private_keys/learning.puppetlabs.vm.pem --cert /etc/puppetlabs/puppet/ssl/certs/learning.puppetlabs.vm.pem -H \"Content-Type: application/json\" -X POST -d '{\"login\":\"learning\",\"display_name\":\"Learning\",\"password\":\"puppet\",\"role_ids\":[2],\"email\":\"learning@puppet.vm\"}' https://localhost:4433/rbac-api/v1/users")
       .exit_status
       .should eq 0

--- a/tests/defined_resource_types_spec.rb
+++ b/tests/defined_resource_types_spec.rb
@@ -96,6 +96,7 @@ describe _("Task 4:"), host: :localhost do
 end
 describe _("Task 5:"), host: :localhost do
   it 'has a working solution', :solution do
+    wait_for_pxp_service
     command("cp #{SOLUTION_PATH}/defined_resource_types/5/pasture_app.pp #{MODULE_PATH}/role/manifests/pasture_app.pp")
       .exit_status
       .should eq 0

--- a/tests/roles_and_profiles_spec.rb
+++ b/tests/roles_and_profiles_spec.rb
@@ -145,6 +145,7 @@ end
 
 describe _("Task 7:"), host: :localhost do
   it 'has a working solution', :solution do
+    wait_for_pxp_service
     command("puppet job run --nodes pasture-db.puppet.vm")
       .exit_status
       .should eq 0

--- a/tests/scripts/quest_nodes.json
+++ b/tests/scripts/quest_nodes.json
@@ -35,8 +35,8 @@
     {"name" : "pasture-prod.puppet.vm"}
   ],
   "the_forge" : [
-    {"name" : "pasture-dev.puppet.vm"},
-    {"name" : "pasture-prod.puppet.vm"}
+    {"name" : "pasture-app.puppet.vm"},
+    {"name" : "pasture-db.puppet.vm"}
   ],
   "roles_and_profiles" : [
     {"name" : "pasture-app-small.puppet.vm"},

--- a/tests/scripts/setup
+++ b/tests/scripts/setup
@@ -3,17 +3,39 @@ require 'socket'
 require 'erb'
 require 'json'
 
+#When you begin a quest, the quest tool (https://github.com/puppetlabs/quest)
+#executes an arbitrary setup_command listed for the quest in the index.json
+#file of its task_dir. For the Learning VM, those commands all follow the
+#pattern "ruby ./scripts/setup <quest_name>", thus passing the quest setup task
+#to this script. Though this adds an extra layer of abstraction, it keeps the
+#a loose coupling between the quest tool and the specific Learning VM quest
+#setup steps that this script handles.
+
 SCRIPT_DIR = File.dirname(__FILE__)
 $stdout.sync = true
 
 def create_node(opts)
+  #Pass a set of node options specified in the "./quest_nodes.json" file through to
+  #the dockeragent module to generate a new container.
+ 
   puts "Creating #{opts['name']}..."
+
+  #This uses the https://github.com/puppetlabs/pltraining-dockeragent module
   `puppet apply -e "dockeragent::node { '#{opts['name']}': ensure => present, image => '#{opts['image']}', require_dockeragent => false, }"`
   wait_for_container(opts['name'])
+
+  #There doesn't seem to be a way to use existing puppet tooling to generate
+  #a CSR from the agent side outside the context of a puppet run.
   if opts['sign_cert']
     `puppet cert generate #{opts['name']}`
     `puppet cert sign #{opts['name']}`
+
+    #It seems to take a moment after the puppet cert sign returns before the
+    #cert is actually signed. A sleep here isn't the most elegant, but because
+    #it only takes a moment, polling would always return after a minimal wait
+    #time anyway.
     sleep 2
+
     `cp -f /etc/puppetlabs/puppet/ssl/certs/#{opts['name']}.pem /etc/docker/ssl_dir/`
     `cp -f /etc/puppetlabs/puppet/ssl/public_keys/#{opts['name']}.pem /etc/docker/ssl_dir/public_keys/`
     `cp -f /etc/puppetlabs/puppet/ssl/private_keys/#{opts['name']}.pem /etc/docker/ssl_dir/private_keys/`
@@ -21,21 +43,57 @@ def create_node(opts)
 end
 
 def run_puppet_on_nodes
-  docker_hosts.each do |name, ip|
-    #Use a bogus tag to only run pluginsync
-    `docker exec -d #{name} puppet agent -t --tags bogus`
+  #This initial agent run handles pxp-service init in the
+  #puppet_enterprise::profile::agent profile class and pluginsync. Doing this
+  #in setup makes the first user initiated run happen faster and more clearly
+  #show the changes the user has introduced.
+
+  manifests_dir = '/etc/puppetlabs/code/environments/production/manifests/'
+
+  begin
+
+    #Using the --tags puppet_enterprise::profile::agent argument ensures that
+    #only the resources in the PE agent profile are run, any compilation errors
+    #still abort the run. For clean catalog compilation, substitute empty site.pp
+    #file, then revert to the original after the runs ar complete.
+   
+    File.rename(File.join(manifests_dir, 'site.pp'), File.join(manifests_dir, 'site.pp.bak'))
+    File.write(File.join(manifests_dir, 'site.pp'),'node default {}')
+
+    #Rather than background these with the docker -d flag and poll for
+    #completion, run in separate threads and join threads after. This obviates
+    #the polling step and avoids race condition issues with site.pp swapping.
+    
+    thread_arr = []
+    docker_hosts.keys.each do |name|
+      puts "Running agent on #{name}..."
+      thread_arr << Thread.new{`docker exec #{name} puppet agent -t --tags puppet_enterprise::profile::agent`}
+    end
+    thread_arr.each(&:join)
+  ensure
+    File.rename(File.join(manifests_dir, 'site.pp.bak'), File.join(manifests_dir, 'site.pp'))
   end
 end
 
 def wait_for_container(name)
-  count = 0
-  while !system("docker ps | grep #{name}") && count < 10 do
-    count =+ 1
+  #Poll the `docker ps` command until the specified container name appears
+  #in the output.
+  
+  puts "Waiting for container #{name}..."
+  retries = 0
+  while !system("docker ps | grep #{name}") do
     sleep 2
+    retries += 1
+    fail "Timed out waiting for #{name} container." if retries > max_retries
   end
 end
 
 def docker_hosts
+  #Parse the output of the `docker ps` command to get a list of containers
+  #currently running and their IP addresses. This is similar to the
+  #docker_hosts fact provided by the dockeragent module, but we prefer to get
+  #it directly.
+  
   hosts = {}
   containers = `docker ps`.split("\n")
   containers.shift
@@ -47,6 +105,9 @@ def docker_hosts
 end
 
 def clear_nodes
+  #Blow away existing nodes before creating those that will be used in the
+  #quest we're starting.
+  
   hosts = docker_hosts
   hosts.each do |name, ip|
     `systemctl stop docker-#{name}.service`
@@ -56,6 +117,8 @@ def clear_nodes
 end
 
 def update_docker_hosts
+  #Regenerate a /etc/hosts file to include the nodes used in this quest.
+  
   hosts = docker_hosts
   fqdn = `facter fqdn`.chomp
 hosts_template = <<-HEREDOC
@@ -70,25 +133,40 @@ HEREDOC
   File.write('/etc/hosts', hosts_string)
 end
 
-def wait_for_ssh
-  puts "Waiting for node SSH services to become available..."
-  docker_hosts.each do |name, ip|
+def poll_nodes(poll_name, max_retries=10, interval=2, initial_sleep=0)
+  #Wrapper function to poll until the supplied block returns a truthy value
+  #or exceeds max retries and fails.
+
+  puts "Waiting for #{poll_name}..."
+  sleep initial_sleep
+  docker_hosts.each do |name, _|
     retries = 0
-    begin
-      Socket.tcp(name, 22, connect_timeout: 5)
-    rescue
-      sleep 2
-      retries +=1
-      if retries > 10
-        puts "Timed out waiting for node SSH services to become available. Please refer the the Learning VM troubleshooting guide."
-        exit 1
-      end
-      retry
+    while !yield(name) do
+      sleep interval
+      retries += 1
+      fail "Timed out waiting for #{poll_name}." if retries > max_retries
     end
   end
 end
 
+def query_ssh(name)
+  #Check if port 22 is listening on the specified container. There may be a
+  #better way to poll SSH than rescue a failed tcp connection!
+
+  begin
+    Socket.tcp(name, 22, connect_timeout: 5).close
+    return true
+  rescue
+    return false
+  end
+end
+
 def node_setup(quest)
+  #Main function of this script. Uses a quest name to look up specs of the
+  #container nodes required, generate those nodes, update /etc/hosts, trigger
+  #an initial puppet run when needed, then wait for SSH to become available on
+  #all nodes before returning.
+  
   run_puppet_after = true
   quest_node_hash = JSON.parse(File.read(File.expand_path('./quest_nodes.json', File.dirname(__FILE__))))
   quest_node_hash[quest].each do |node|
@@ -98,12 +176,16 @@ def node_setup(quest)
       'run_puppet' => true
     }
     opts = default_opts.merge(node)
+    #Only run puppet if run_puppet is true for all nodes. Ideally, this would
+    #be a per-quest parameter rather than per node, as it should be all or
+    #none, but currently data is structured to include opts per node, rather
+    #than per-quest.
     run_puppet_after &= opts['run_puppet']
     create_node(opts)
   end
   update_docker_hosts
   run_puppet_on_nodes if run_puppet_after
-  wait_for_ssh
+  poll_nodes("SSH", 10){ |name| query_ssh(name) }
 end
 
 clear_nodes

--- a/tests/spec_helper.rb
+++ b/tests/spec_helper.rb
@@ -12,6 +12,35 @@ SOLUTION_PATH = File.expand_path('../solution_files/', __FILE__)
 GettextSetup.initialize(File.expand_path('./locales', File.dirname(__FILE__)))
 GettextSetup.negotiate_locale!(GettextSetup.candidate_locales)
 
+def docker_hosts
+  hosts = {}
+  containers = `docker ps`.split("\n")
+  containers.shift
+  containers.each do |line|
+    name = line.split.last
+    hosts[name] = `docker inspect -f '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' #{name}`.chomp
+  end
+  return hosts
+end
+
+def poll_nodes(poll_name, max_retries=10, interval=2, initial_sleep=0)
+  sleep initial_sleep
+  docker_hosts.each do |name, _|
+    retries = 0
+    while !yield(name) do
+      sleep interval
+      retries += 1
+      fail "Timed out waiting for #{poll_name}." if retries > max_retries
+    end
+  end
+end
+
+def wait_for_pxp_service
+  poll_nodes("pxp-agent service", max_retries=20) do |name|
+    system("docker exec -it #{name} systemctl status pxp-agent.service | grep 'running'")
+  end
+end
+
 set :backend, :exec
 
 ### enable both :should and :expect syntax ###

--- a/tests/the_forge_spec.rb
+++ b/tests/the_forge_spec.rb
@@ -43,6 +43,7 @@ end
 
 describe _("Task 3:"), host: :localhost do
   it 'has a working solution', :solution do
+    wait_for_pxp_service
     command("cp #{SOLUTION_PATH}/the_forge/3/site.pp #{PROD_PATH}/manifests/site.pp")
       .exit_status
       .should eq 0


### PR DESCRIPTION
Improve polling methods to wait for necessary services to come up on
containerized agent nodes. Move pxp-agent polling to spec test files, as
it is too time-consuming to wait for it to complete during the setup
step, but is needed before spec tests can be completed.