### PR TITLE
(LEARNVM-635) Add PuppetHack environment option to setup

### DIFF
--- a/tests/scripts/quest_nodes.json
+++ b/tests/scripts/quest_nodes.json
@@ -49,5 +49,10 @@
   "application_orchestrator" : [
     {"name" : "pasture-app-large.puppet.vm"},
     {"name" : "pasture-db.puppet.vm"}
+  ],
+  "puppethack" : [
+    {"name" : "hack1.puppet.vm"},
+    {"name" : "hack2.puppet.vm"},
+    {"name" : "hack3.puppet.vm"}
   ]
 }

--- a/tests/scripts/setup
+++ b/tests/scripts/setup
@@ -30,8 +30,8 @@ def create_node(opts)
   #necessary files to the /etc/docker/ssl_dir/ directory, which is mounted on
   #the docker nodes.
   if opts['sign_cert']
-    `puppet cert generate #{opts['name']}`
-    `puppet cert sign #{opts['name']}`
+    `puppet cert generate #{opts['name']} > /dev/null 2>&1`
+    `puppet cert sign #{opts['name']} > /dev/null 2>&1`
 
     #It seems to take a moment after the puppet cert sign returns before the
     #cert is actually signed. A sleep here isn't the most elegant, but because


### PR DESCRIPTION
Add an option to create a set of nodes to be used in 2017 PuppetHack
event. These will be available when running the setup script directly,
with the puppethack argument, but will not be exposed by the quest tool.

Because the output of the setup script will be shown when run directly,
this also redirects the output of the cert signing commands (which are
expected to fail in some circumstances) to /dev/null. This will keep
users from becoming unduly concerned about red text in the setup
script's output.