### PR TITLE
(MAINT) Update postgresql module to 4.9.0

### DIFF
--- a/tests/the_forge_spec.rb
+++ b/tests/the_forge_spec.rb
@@ -13,7 +13,7 @@ end
 
 describe _("Task 1:"), host: :localhost do
   it 'has a working solution', :solution do
-    command("puppet module install puppetlabs-postgresql --version 4.8.0")
+    command("puppet module install puppetlabs-postgresql --version 4.9.0")
       .exit_status
       .should eq 0
   end

--- a/us_en/quests/the_forge.md
+++ b/us_en/quests/the_forge.md
@@ -99,7 +99,7 @@ the Puppetfile and code management workflow
 On your master, go ahead and use the `puppet module` tool to install this
 module.
 
-    puppet module install puppetlabs-postgresql --version 4.8.0
+    puppet module install puppetlabs-postgresql --version 4.9.0
 
 To confirm that this command placed the module in your modulepath, take a look
 at the contents of your modules directory.


### PR DESCRIPTION
There is an issue related to a duplicated default block in 4.8.0 that seemed to work prior to 2017.3.2 but now causes errors. See corresponding change to the bootstrap repository:
https://github.com/puppetlabs/pltraining-bootstrap/pull/319