### PR TITLE
(LEARNVM-637) Disable application orchestrator content

### DIFF
--- a/tests/index.json
+++ b/tests/index.json
@@ -46,9 +46,5 @@
   "defined_resource_types": {
     "watch_list": ["/root/.bash_history"],
     "setup_command": "ruby ./scripts/setup defined_resource_types"
-  },
-  "application_orchestrator": {
-    "watch_list": ["/root/.bash_history"],
-    "setup_command": "ruby ./scripts/setup application_orchestrator"
   }
 }

--- a/us_en/summary.md
+++ b/us_en/summary.md
@@ -18,7 +18,6 @@
 * [The Forge](quests/the_forge.md)
 * [Roles and Profiles](quests/roles_and_profiles.md)
 * [Defined Resource Types](quests/defined_resource_types.md)
-* [Application Orchestrator](quests/application_orchestrator.md)
 
 ### Appendix
 


### PR DESCRIPTION
This will be replaced by tasks content in an upcoming release.
Considering this and that the ordering of the final several quests will
be changed to accomidate hiera content, it doesn't make sense to
continue maintenance in the mean time.