### PR TITLE
Correct logic error in example "if" test

### DIFF
--- a/en_us/quests/conditional_statements.md
+++ b/en_us/quests/conditional_statements.md
@@ -265,7 +265,7 @@ class pasture (
     ensure    => running,
   }
 
-  if $sinatra_server == 'thin' or 'mongrel'  {
+  if ($sinatra_server == 'thin') or ($sinatra_server == 'mongrel')  {
     package { $sinatra_server:
       provider => 'gem',
       notify   => Service['pasture'],

--- a/en_us/quests/the_forge.md
+++ b/en_us/quests/the_forge.md
@@ -248,7 +248,7 @@ class pasture (
     ensure    => running,
   }
 
-  if $sinatra_server == 'thin' or 'mongrel'  {
+  if ($sinatra_server == 'thin') or ($sinatra_server == 'mongrel')  {
     package { $sinatra_server:
       provider => 'gem',
       notify   => Service['pasture'],

--- a/ja_jp/quests/conditional_statements.md
+++ b/ja_jp/quests/conditional_statements.md
@@ -198,7 +198,7 @@ class pasture (
     ensure    => running,
   }
 
-  if $sinatra_server == 'thin' or 'mongrel'  {
+  if ($sinatra_server == 'thin') or ($sinatra_server == 'mongrel')  {
     package { $sinatra_server:
       provider => 'gem',
       notify   => Service['pasture'],

--- a/ja_jp/quests/the_forge.md
+++ b/ja_jp/quests/the_forge.md
@@ -170,7 +170,7 @@ class pasture (
     ensure    => running,
   }
 
-  if $sinatra_server == 'thin' or 'mongrel'  {
+  if ($sinatra_server == 'thin') or ($sinatra_server == 'mongrel')  {
     package { $sinatra_server:
       provider => 'gem',
       notify   => Service['pasture'],

--- a/tests/conditional_statements_spec.rb
+++ b/tests/conditional_statements_spec.rb
@@ -53,7 +53,7 @@ describe _("Task 3:"), host: :localhost do
   it _('Conditionally manage the Sinatra server package'), :validation do
     file("#{MODULE_PATH}pasture/manifests/init.pp")
       .content
-      .should match /if\s+\$sinatra_server\s+==\s+(['"])thin\1\s+or\s+(['"])mongrel\1\s+\{.*?package\s+\{\s+\$sinatra_server:/m
+      .should match /if\s+\(\$sinatra_server\s+==\s+(['"])thin\1\)\s+or\s+\(\$sinatra_server\s+==\s+(['"])mongrel\2\)\s+\{.*?package\s+\{\s+\$sinatra_server:/m
     command("puppet parser validate #{MODULE_PATH}pasture/manifests/init.pp")
       .exit_status
       .should be_zero

--- a/tests/solution_files/conditional_statements/3/init.pp
+++ b/tests/solution_files/conditional_statements/3/init.pp
@@ -37,7 +37,7 @@ class pasture (
     ensure    => running,
   }
 
-  if $sinatra_server == 'thin' or 'mongrel'  {
+  if ($sinatra_server == 'thin') or ($sinatra_server == 'mongrel')  {
     package { $sinatra_server:
       provider => 'gem',
       notify   => Service['pasture'],

--- a/tests/solution_files/the_forge/4/init.pp
+++ b/tests/solution_files/the_forge/4/init.pp
@@ -39,7 +39,7 @@ class pasture (
     ensure    => running,
   }
 
-  if $sinatra_server == 'thin' or 'mongrel'  {
+  if ($sinatra_server == 'thin') or ($sinatra_server == 'mongrel')  {
     package { $sinatra_server:
       provider => 'gem',
       notify   => Service['pasture'],


### PR DESCRIPTION
The if statement is not logically valid.

```puppet
if $sinatra_server == 'thin' or 'mongrel'
```

Due to order of operations, `==` happens before `or`. Therefore this test
always evaluates true, because 'mongrel' is a non-empty string.