### PR TITLE
(TRAINTECH-6775)(TRAINTECH-6776) Update URLs in quests and tests

### DIFF
--- a/en_us/quests/agent_run.md
+++ b/en_us/quests/agent_run.md
@@ -106,7 +106,7 @@ Puppet administrator can then validate that the system sending the CSR should
 be allowed to request catalogs from the master before deciding to sign the
 certificate. (You can read more about the details of Puppet's cryptographic
 security and the certification system on the [docs
-page](https://docs.puppet.com/background/ssl/index.html))
+page](https://puppet.com/docs/pe/latest/ssl_and_certificates.html))
 
 <div class = "lvm-task-number"><p>Task 1:</p></div>
 
@@ -134,7 +134,7 @@ You'll see a notification like the following:
 No problem: you just have to sign the certificate. For now, we'll show you how
 to do it from the command line. If you prefer a GUI, the PE console includes
 [tools for certificate
-management](https://docs.puppet.com/pe/latest/console_cert_mgmt.html).
+management](https://puppet.com/docs/pe/latest/adding_and_removing_nodes.html).
 
 <div class = "lvm-task-number"><p>Task 2:</p></div>
 
@@ -174,7 +174,7 @@ receive a catalog from the Puppet master.
 
 While you haven't yet told Puppet to manage any resources on the system, you'll
 see a lot of text scroll by. Most of what you see is a process called
-[pluginsync](https://docs.puppet.com/puppet/latest/plugins_in_modules.html#auto-download-of-agent-side-plugins-pluginsync).
+[pluginsync](https://puppet.com/docs/puppet/latest/plugins_in_modules.html#auto-download-of-agent-side-plug-ins-pluginsync).
 During pluginsync, any extensions installed on the master (such as custom
 facts, resource types, or providers) are copied to the Puppet agent before the
 Puppet run continues. This ensures that the agent has all the tools it needs to
@@ -242,7 +242,7 @@ very efficient way to manage node classification, you'll understand it best afte
 
 3. Finally, if you want to customize node classification, you can create your
 own [external node
-classifier](https://docs.puppet.com/guides/external_nodes.html). An external
+classifier](https://puppet.com/docs/puppet/latest/nodes_external.html). An external
 node classifier can be any executable that takes the name of a node as an
 argument and returns a YAML file describing the Puppet code to be applied to
 that node. This is an advanced topic and is not covered in this guide.
@@ -301,7 +301,7 @@ will default to the resource title. This lets us save some time by leaving out
 the parameter value pairs and using the title to define the message we want the
 resource to display. (This parameter that uses the resource title as its
 default is called a **namevar**. You can read more about the role of the
-namevar in the [Puppet docs](https://docs.puppet.com/puppet/latest/lang_resources.html))
+namevar in the [Puppet docs](https://puppet.com/docs/puppet/latest/lang_resources.html#namenamevar))
 
 Now that you have a concrete example of a node declaration, let's return to our
 review of the agent run process from the master's perspective. When the agent
@@ -361,5 +361,5 @@ Puppet is built on.
 
 ## Additional Resources
 
-* Read about the basics of a Puppet agent run on our [docs page](https://docs.puppet.com/pe/latest/console_classes_groups_running_puppet.html)
+* Read about the basics of a Puppet agent run on our [docs page](https://puppet.com/docs/pe/latest/run_puppet_on_nodes.html)
 * Puppet agent concepts are covered in-depth in our Puppet Fundamentals and Puppetizing Infrastructure courses. Explore our [in-person](https://learn.puppet.com/category/instructor-led-training) and [online](https://learn.puppet.com/category/online-instructor-led-training) training options for more information.

--- a/en_us/quests/application_orchestrator.md
+++ b/en_us/quests/application_orchestrator.md
@@ -487,7 +487,7 @@ Before getting into the specifics of defining an application and running it as
 a job, we covered the configuration details on the Puppet agent nodes and the
 setup for the Puppet Application Orchestrator client. You can review these
 steps and find further information at the [Puppet
-Documentation](https://docs.puppet.com/pe/latest/app_orchestration_overview.html)
+Documentation](https://puppet.com/docs/pe/latest/application_orchestration_overview.html)
 website.
 
 Defining an application generally requires several distinct manifests and Ruby extensions:
@@ -506,6 +506,6 @@ completed jobs with the `puppet job show` command.
 
 ## Additional Resources
 
-* Read more about application orchestration at our [docs page](https://docs.puppet.com/pe/latest/app_orchestration_overview.html).
+* Read more about application orchestration at our [docs page](https://puppet.com/docs/pe/latest/application_orchestration_overview.html).
 * Check out an overview of the feature on the [product page](https://puppet.com/product/capabilities/orchestration).
 * If you’re interested in a concrete demonstration, look at this [example application GitHub repository](https://github.com/puppetlabs/puppetlabs-wordpress_app).

--- a/en_us/quests/class_parameters.md
+++ b/en_us/quests/class_parameters.md
@@ -218,5 +218,5 @@ introduce data about your agent system into your Puppet code.
 
 ## Additional Resources
 
-* Check out our [docs page on classes](https://docs.puppet.com/puppet/latest/lang_classes.html) for more information.
-* If you're interested in more advanced methods for adding data to your classes, you might want to read about [using modules with Hiera](https://docs.puppet.com/puppet/latest/hiera_migrate_modules.html).
+* Check out our [docs page on classes](https://puppet.com/docs/puppet/latest/lang_classes.html) for more information.
+* If you're interested in more advanced methods for adding data to your classes, you might want to read about [using modules with Hiera](https://puppet.com/docs/puppet/latest/hiera_migrate.html#adding-hiera-data-to-a-module).

--- a/en_us/quests/conditional_statements.md
+++ b/en_us/quests/conditional_statements.md
@@ -49,7 +49,7 @@ set based on an `if` statement using the `osfamily` fact. (You may notice that
 this module uses an un-structured `$::osfamily` format for this fact to
 preserve backwards compatibility. You can read more about this form of
 reference on [the docs
-page](https://docs.puppet.com/puppet/latest/lang_facts_and_builtin_vars.html#classic-factname-facts))
+page](https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html#classic-factname-facts))
 
 Simplified to show only the values we're concerned with, the conditional
 statement looks like this:
@@ -283,7 +283,7 @@ for production.
 We created two new systems for this quest: `pasture-dev.puppet.vm` and
 `pasture-prod.puppet.vm`. For a more complex infrastructure, you would likely
 manage your development, test, and production segments of your infrastructure
-by creating a distinct [environment](https://docs.puppet.com/puppet/latest/environments.html)
+by creating a distinct [environment](https://puppet.com/docs/puppet/latest/environments_about.html)
 for each. For now, however, we can easily demonstrate our conditional statement
 by setting up two different node definitions in the `site.pp` manifest.
 
@@ -414,5 +414,5 @@ backend for the Pasture application.
 
 ## Additional Resources
 
-* Puppet's [docs page](https://docs.puppet.com/puppet/latest/lang_conditional.html) covers the syntax of all forms of conditional statements and expressions.
-* The [style guide](https://docs.puppet.com/puppet/latest/style_guide.html#conditionals) includes best-practices recommendations for the use of conditionals.
+* Puppet's [docs page](https://puppet.com/docs/puppet/latest/lang_conditional.html) covers the syntax of all forms of conditional statements and expressions.
+* The [style guide](https://puppet.com/docs/puppet/latest/style_guide.html#conditionals) includes best-practices recommendations for the use of conditionals.

--- a/en_us/quests/defined_resource_types.md
+++ b/en_us/quests/defined_resource_types.md
@@ -51,7 +51,7 @@ When you're ready to get started, type the following command:
 > -Søren Kierkegaard
 
 A [defined resource
-type](https://docs.puppet.com/puppet/latest/lang_defined_types.html) is a block
+type](https://puppet.com/docs/puppet/latest/lang_defined_types.html) is a block
 of Puppet code that can be evaluated multiple times within a single node's
 catalog.
 
@@ -270,7 +270,7 @@ define user_accounts::ssh_user (
 You may have noticed another new element of syntax into this code. Some of the
 double-quoted strings (`"..."`) in this manifest include variables in the
 `${var_name}` format. This is Puppet's [string
-interpolation](https://docs.puppet.com/puppet/latest/lang_variables.html#interpolation)
+interpolation](https://puppet.com/docs/puppet/latest/lang_variables.html#interpolation)
 syntax. String interpolation allows you to insert a variable into any
 double-quoted string.
 
@@ -520,5 +520,5 @@ on a defined resource type:
 
 ## Additional Resources
 
-* Read more about defined resource types at our [docs page](https://docs.puppet.com/puppet/latest/lang_defined_types.html).
+* Read more about defined resource types at our [docs page](https://puppet.com/docs/puppet/latest/lang_defined_types.html).
 * Defined resource types are covered in our Puppet Fundamentals, Puppet Practitioner, and Puppetizing Infrastructure courses. Explore our [in-person](https://learn.puppet.com/category/instructor-led-training) and [online](https://learn.puppet.com/category/online-instructor-led-training) training options for more information.

--- a/en_us/quests/facts.md
+++ b/en_us/quests/facts.md
@@ -223,6 +223,6 @@ create intelligent defaults based on system information.
 
 ## Additional Resources
 
-* Check out our [docs page](https://docs.puppet.com/puppet/latest/lang_facts_and_builtin_vars.html) for more information on facter and facts in Puppet.
-* You can also find a [lesson on Facter](https://learn.puppet.com/elearning/an-introduction-to-facter) in our [self-paced training course catalog](https://learn.puppet.com/category/self-paced-training).
+* Check out our [docs page](https://puppet.com/docs/puppet/latest/lang_facts_and_builtin_vars.html) for more information on facter and facts in Puppet.
+* You can also find a [lesson on Facter](https://learn.puppet.com/course/an-introduction-to-facter) in our [self-paced training course catalog](https://learn.puppet.com/category/self-paced-training).
 * Facts are covered in-depth in our Puppet Fundamentals, Puppet Practitioner, and Puppetizing Infrastructure courses. Explore our [in-person](https://learn.puppet.com/category/instructor-led-training) and [online](https://learn.puppet.com/category/online-instructor-led-training) training options for more information.

--- a/en_us/quests/hello_puppet.md
+++ b/en_us/quests/hello_puppet.md
@@ -159,7 +159,7 @@ installation script available. In this case, our master and agent are both
 running CentOS 7, so we don't have to worry about this difference. You can find
 full documentation of the agent installation process, including specific
 instructions for Windows and other operating systems in the [installation
-documentation](https://docs.puppet.com/pe/latest/install_agents.html).
+documentation](https://puppet.com/docs/pe/latest/installing_agents.html).
 
 ## Resources
 
@@ -212,7 +212,7 @@ The body of a resource is a list of **parameter value pairs** that follow the
 pattern `parameter => value`. The parameters and possible values vary from type
 to type. They specify the state of the resource on the system. Documentation
 for resource parameters is provided in the [Resource Type
-Reference](https://docs.puppet.com/puppet/latest/reference/type.html).
+Reference](https://puppet.com/docs/puppet/latest/types/).
 
 The **resource title** is a unique name that Puppet uses to identify the
 resource internally. In the case of our file resource that you looked at above, the
@@ -237,7 +237,7 @@ not explicilty set. The same pattern applies for other resources, such as a
 user's account name or package name as we mentioned above. This parameter that
 defaults to the title is called a **namevar**. You can find more information
 about the **namevar** for different resource types in the [Resource Type
-Reference](https://docs.puppet.com/puppet/latest/reference/type.html).
+Reference](https://puppet.com/docs/puppet/latest/types/).
 
 Now that you're more familiar with the resource syntax, let's take another look
 at that file resource.
@@ -431,6 +431,6 @@ kept on the master.
 ## Additional Resources
 
 * Watch our on-demand webinar ["Introduction to Puppet Enterprise"](https://puppet.com/resources/webinar/introduction-puppet-enterprise)
-* Read about installing Puppet Enterprise on our [docs page](https://docs.puppet.com/pe/latest/install_basic.html)
-* Take a look at our [What is Puppet](https://learn.puppet.com/elearning/what-is-puppet) and [What is Puppet Enterprise](https://learn.puppet.com/elearning/what-is-puppet-enterprise) and [Resources](https://learn.puppet.com/elearning/resources) [self-paced lessons](https://learn.puppet.com/category/self-paced-training).
+* Read about installing Puppet Enterprise on our [docs page](https://puppet.com/docs/pe/latest/installing_pe.html)
+* Take a look at our [What is Puppet](https://learn.puppet.com/course/what-is-puppet) and [What is Puppet Enterprise](https://learn.puppet.com/course/what-is-puppet-enterprise) and [Resources](https://learn.puppet.com/course/resources) [self-paced lessons](https://learn.puppet.com/category/self-paced-training).
 * Puppet basics are covered in-depth in our Puppet Fundamentals and Puppetizing Infrastructure courses. Explore our [in-person](https://learn.puppet.com/category/instructor-led-training) and [online](https://learn.puppet.com/category/online-instructor-led-training) training options for more information.

--- a/en_us/quests/hiera.md
+++ b/en_us/quests/hiera.md
@@ -26,7 +26,7 @@ When you're ready to get started, type the following command:
 All of the methods for managing data you've encountered so far in this guide,
 from variables and templates to the roles and profiles pattern, get you closer
 to a clean separation of data from code.
-[Hiera](https://docs.puppet.com/puppet/latest/hiera_intro.html) is Puppet's
+[Hiera](https://puppet.com/docs/puppet/latest/hiera_intro.html) is Puppet's
 built-in data lookup system. It lets you complete this separation by moving
 data out of your Puppet manifests and into a separate data source.
 
@@ -38,8 +38,8 @@ level overrides the default set on the more general level. Between these
 most-general and most-specific levels, Hiera allows you to specify any number
 of intermediate levels.
 
-Though we haven't addressed the topic in this guide, implementing (custom and
-external facts)[https://docs.puppet.com/facter/latest/custom_facts.html] gives
+Though we haven't addressed the topic in this guide, implementing [custom and
+external facts](https://puppet.com/docs/facter/latest/custom_facts.html) gives
 you great leeway in setting up your Hiera hierarchies. For example, you might
 include a Hiera level corresponding to a country to specify default locale
 configuration for a set of workstations or a level corresponding to datacenter

--- a/en_us/quests/manifests_and_classes.md
+++ b/en_us/quests/manifests_and_classes.md
@@ -386,6 +386,6 @@ scheme to structure the Puppet code you write.
 
 ## Additional Resources
 
-* Module fundamentals and structure are covered on our [docs page](https://docs.puppet.com/puppet/latest/modules_fundamentals.html), along with other topics such as module testing and publishing to the Forge.
+* Module fundamentals and structure are covered on our [docs page](https://puppet.com/docs/puppet/latest/modules_fundamentals.html), along with other topics such as module testing and publishing to the Forge.
 * Puppet modules are covered in-depth in our Puppet Fundamentals, Puppet Practitioner, and Puppetizing Infrastructure courses. Explore our [in-person](https://learn.puppet.com/category/instructor-led-training) and [online](https://learn.puppet.com/category/online-instructor-led-training) training options for more information.
-* [Classes](https://learn.puppet.com/elearning/classes) and [Autoloading](https://learn.puppet.com/elearning/autoloading) are covered as self-paced lessons.
+* [Classes](https://learn.puppet.com/course/classes) and [Autoloading](https://learn.puppet.com/course/autoloading) are covered as self-paced lessons.

--- a/en_us/quests/package_file_service.md
+++ b/en_us/quests/package_file_service.md
@@ -199,7 +199,7 @@ Don't worry if this URI syntax seems complex. It's pretty rare that you'll need
 to use it for anything other than referring to files within your modules, so
 the pattern above is likely all you'll need to learn. You can always refer back
 to the
-[docs](https://docs.puppet.com/puppet/latest/reference/types/file.html#file-attribute-source)
+[docs](https://puppet.com/docs/puppet/latest/types/file.html#file-attribute-source)
 for a reminder.
 
 <div class = "lvm-task-number"><p>Task 9:</p></div>
@@ -329,7 +329,7 @@ pick up those changes.
 Though Puppet code will default to managing resources in the order they're
 written in a manifest, we strongly recommend that you make dependencies among
 resources explicit through [relationship
-metaparameters](https://docs.puppet.com/puppet/latest/lang_relationships.html#syntax-relationship-metaparameters).
+metaparameters](https://puppet.com/docs/puppet/latest/lang_relationships.html#syntax-relationship-metaparameters).
 A metaparameter is a parameter, that affects *how* Puppet handles a resource
 rather than directly defining its desired state. Relationship metaparameters
 tell Puppet about ordering relationships among your resources.
@@ -343,7 +343,7 @@ useful when you need Puppet to restart a service to pick up changes in a
 configuration file.
 
 Relationship metaparameters take a [resource
-reference](https://docs.puppet.com/puppet/latest/lang_data_resource_reference.html)
+reference](https://puppet.com/docs/puppet/latest/lang_data_resource_reference.html)
 as a value. This resource reference points to another resource in your Puppet
 code. The syntax for a resource reference is the capitalized resource type,
 followed by square brackets containing the resource title: `Type['title']`. 
@@ -434,5 +434,5 @@ variables and replacing your static files with templates.
 
 ## Additional Resources
 
-* Our [docs page](https://docs.puppet.com/puppet/latest/lang_relationships.html) covers resource relationships in more depth, including some alternative syntax forms you might run into reading others’ Puppet code.
-* Resource relationships are also covered by [a lesson](https://learn.puppet.com/elearning/relationships) in our [self-paced course catalog](https://learn.puppet.com/category/self-paced-training).
+* Our [docs page](https://puppet.com/docs/puppet/latest/lang_relationships.html) covers resource relationships in more depth, including some alternative syntax forms you might run into reading others’ Puppet code.
+* Resource relationships are also covered by [a lesson](https://learn.puppet.com/course/relationships) in our [self-paced course catalog](https://learn.puppet.com/category/self-paced-training).

--- a/en_us/quests/roles_and_profiles.md
+++ b/en_us/quests/roles_and_profiles.md
@@ -282,9 +282,9 @@ any other special character, you will need to escape it with a backslash
 overly complex, it may be a sign that you need to revisit your node naming
 scheme or look into an alternate classification method such as the PE console
 [node
-classifier](https://docs.puppet.com/pe/latest/console_classes_groups.html) or
+classifier](https://puppet.com/docs/pe/latest/grouping_and_classifying_nodes.html) or
 an [external node
-classifier](https://docs.puppet.com/puppet/latest/nodes_external.html).
+classifier](https://puppet.com/docs/puppet/latest/nodes_external.html).
 
 <div class = "lvm-task-number"><p>Task 6:</p></div>
 
@@ -365,9 +365,9 @@ infrastructure.
 
 ## Additional Resources
 
-* Read more about Roles and Profiles at our [docs page](https://docs.puppet.com/pe/latest/r_n_p_intro.html)
+* Read more about Roles and Profiles at our [docs page](https://puppet.com/docs/pe/latest/the_roles_and_profiles_method.html)
 * Have a look at the [blog post](http://garylarizza.com/blog/2014/02/17/puppet-workflow-part-1/) that helped establish the Roles and Profiles pattern as a recommended Puppet workflow.
-* Learn more about Roles and Profiles in our [self-paced course](https://learn.puppet.com/elearning/an-introduction-to-roles-profiles)
+* Learn more about Roles and Profiles in our [self-paced course](https://learn.puppet.com/course/an-introduction-to-roles-profiles)
 * Roles and Profiles are covered in our Puppet Practitioner, and Puppetizing Infrastructure courses. Explore our [in-person](https://learn.puppet.com/category/instructor-led-training) and [online](https://learn.puppet.com/category/online-instructor-led-training) training options for more information.
-* You can learn more about using regular expressions in node definitions on our [docs page](https://docs.puppet.com/puppet/latest/lang_node_definitions.html#regular-expression-names) .
+* You can learn more about using regular expressions in node definitions on our [docs page](https://puppet.com/docs/puppet/latest/lang_node_definitions.html#regular-expression-names) .
 * You can find a tool to easily test your regular expressions [here](http://rubular.com).

--- a/en_us/quests/the_forge.md
+++ b/en_us/quests/the_forge.md
@@ -92,7 +92,7 @@ quest, we'll use the simpler `puppet module` tool. (As you start managing a
 more complex Puppet environment and checking your Puppet code into a control
 repository, however, using a Puppetfile is recommended. You can read more about
 the Puppetfile and code management workflow
-[here](https://docs.puppet.com/pe/latest/cmgmt_managing_code.html).)
+[here](https://puppet.com/docs/pe/latest/managing_puppet_code.html).)
 
 <div class = "lvm-task-number"><p>Task 1:</p></div>
 
@@ -342,4 +342,4 @@ create a database server and connect it to your application server.
 
 * Watch this [short video](https://fast.wistia.net/embed/iframe/uxfpduvk64?seo=false) for a basic introduction to the Forge.
 * For more in-depth information on the Forge, check our [Introduction to the Forge](https://learn.puppet.com/elearning/an-introduction-to-the-forge) self-paced course.
-* Our [Puppetizing Infrastructure](https://learn.puppet.com/instructor-led-training/puppetizing-infrastructure)  course focuses on using Forge modules to quickly get started managing your infrastructure with Puppet.
+* Our [Puppetizing Infrastructure](https://learn.puppet.com/instructor-led-training/puppetizing-infrastructure) course focuses on using Forge modules to quickly get started managing your infrastructure with Puppet.

--- a/en_us/quests/variables_and_templates.md
+++ b/en_us/quests/variables_and_templates.md
@@ -116,7 +116,7 @@ The limitation of templates is that they're all-or-nothing. The template must
 define the entire file you want to manage. If you need to manage only a single
 line or value in a file because another process or Puppet module will manage a
 different part of the file, you may want to investigate
-[Augeas](https://docs.puppet.com/guides/augeas.html),
+[Augeas](https://puppet.com/docs/puppet/latest/resources_augeas.html),
 [concat](https://forge.puppet.com/puppetlabs/concat), or the
 [file_line](https://forge.puppet.com/puppetlabs/stdlib#file_line) resource
 type.
@@ -124,9 +124,9 @@ type.
 ## Embedded Puppet templating language
 
 Puppet supports two templating languages, [Embedded Puppet
-(EPP)](https://docs.puppet.com/puppet/latest/lang_template_epp.html) and
+(EPP)](https://puppet.com/docs/puppet/latest/lang_template_epp.html) and
 [Embedded Ruby
-(ERB)](https://docs.puppet.com/puppet/latest/lang_template_erb.html).
+(ERB)](https://puppet.com/docs/puppet/latest/lang_template_erb.html).
 
 EPP templates were released in Puppet 4 to provide a Puppet-native templating
 language that would offer several improvements over the ERB templates that had
@@ -396,5 +396,5 @@ is configured without editing code in the module where the class is defined.
 
 ## Additional Resources
 
-* Our docs page has more information on [variables](https://docs.puppet.com/puppet/latest/lang_variables.html) and [templates](https://docs.puppet.com/puppet/latest/lang_template.html).
+* Our docs page has more information on [variables](https://puppet.com/docs/puppet/latest/lang_variables.html) and [templates](https://puppet.com/docs/puppet/latest/lang_template.html).
 * These topics are also covered in more depth in our [in-person](https://learn.puppet.com/category/instructor-led-training) and [online](https://learn.puppet.com/category/online-instructor-led-training) trainings.

--- a/tests/solution_files/agent_run/4/site.pp
+++ b/tests/solution_files/agent_run/4/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/application_orchestrator/6/site.pp
+++ b/tests/solution_files/application_orchestrator/6/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/application_orchestrator/7/site.pp
+++ b/tests/solution_files/application_orchestrator/7/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/class_parameters/2/site.pp
+++ b/tests/solution_files/class_parameters/2/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/conditional_statements/4/site.pp
+++ b/tests/solution_files/conditional_statements/4/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/control_repository/3/environment.conf
+++ b/tests/solution_files/control_repository/3/environment.conf
@@ -1,11 +1,15 @@
 # Each environment can have an environment.conf file. Its settings will only
 # affect its own environment. See docs for more info:
-# https://docs.puppetlabs.com/puppet/latest/reference/config_file_environment.html
+# https://puppet.com/docs/puppet/latest/config_file_environment.html
+
 # Any unspecified settings use default values; some of those defaults are based
 # on puppet.conf settings.
+
 # If these settings include relative file paths, they'll be resolved relative to
 # this environment's directory.
+
 # Allowed settings and default values:
+
 # modulepath = ./modules:$basemodulepath
 # manifest = (default_manifest from puppet.conf, which defaults to ./manifests)
 # config_version = (no script; Puppet will use the time the catalog was compiled)

--- a/tests/solution_files/facts/5/site.pp
+++ b/tests/solution_files/facts/5/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/manifests_and_classes/4/site.pp
+++ b/tests/solution_files/manifests_and_classes/4/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/package_file_service/3/site.pp
+++ b/tests/solution_files/package_file_service/3/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/roles_and_profiles/6/site.pp
+++ b/tests/solution_files/roles_and_profiles/6/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/the_forge/3/site.pp
+++ b/tests/solution_files/the_forge/3/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node

--- a/tests/solution_files/the_forge/5/site.pp
+++ b/tests/solution_files/the_forge/5/site.pp
@@ -6,7 +6,7 @@
 # Global objects like filebuckets and resource defaults should go in this file,
 # as should the default node definition. (The default node can be omitted
 # if you use the console and don't define any other nodes in site.pp. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.)
 
 ## Active Configurations ##
@@ -16,7 +16,7 @@ File { backup => false }
 
 # DEFAULT NODE
 # Node definitions in this file are merged with node data from the console. See
-# http://docs.puppetlabs.com/guides/language_guide.html#nodes for more on
+# https://puppet.com/docs/puppet/latest/lang_summary.html for more on
 # node definitions.
 
 # The default node definition matches any node lacking a more specific node


### PR DESCRIPTION
Several URLs pointing to docs and self-guided courses in the quest guide and tests are outdated. Update those URLs to point to current content.