### PR TITLE
Found API error in the URL for checking repo branch

### DIFF
--- a/tests/control_repository_spec.rb
+++ b/tests/control_repository_spec.rb
@@ -189,7 +189,7 @@ describe _("Task 12:"), host: :localhost do
   xit 'has a working solution', :solution do
   end
   it _("Change the upstream repository's default branch to production") do
-    command("curl -i http://learning:puppet@localhost:3000/api/v1/users/learning/control-repo")
+    command("curl -i http://learning:puppet@localhost:3000/api/v1/repos/learning/control-repo")
       .stdout
       .should match /"default_branch":"production"/
   end


### PR DESCRIPTION
Hello Puppet, 

During my learning on the Learning Puppet vm 6.5, I found an error with the API for accessing Gitea. It looks like maybe the API's were changed but it was referencing `users` instead of `repos`.

Changes in this Pull Request:
* Changed the API URL from `users` to `repos`

Example output that passes the testing. 

```
# curl -i http://learning:puppet@localhost:3000/api/v1/repos/learning/control-repo
HTTP/1.1 200 OK
Content-Type: application/json; charset=UTF-8
Set-Cookie: lang=en-US; Path=/; Max-Age=2147483647
Set-Cookie: i_like_gitea=60cee650497f8c63; Path=/; HttpOnly
Set-Cookie: _csrf=51idYhFL_iFpgYftDeEITjfNWmQ6MTU0NTQ2Njg2ODQ4MjMyMzI5MA%3D%3D; Path=/; Expires=Sun, 23 Dec 2018 08:21:08 GMT; HttpOnly
X-Frame-Options: SAMEORIGIN
Date: Sat, 22 Dec 2018 08:21:08 GMT
Content-Length: 773

{"id":1,"owner":{"id":2,"login":"learning","full_name":"","email":"learning@puppet.vm","avatar_url":"https://secure.gravatar.com/avatar/2ba79be16b6a8b47d6d255ead35be86e","username":"learning"},"name":"control-repo","full_name":"learning/control-repo","description":"","empty":false,"private":false,"fork":false,"parent":null,"mirror":false,"size":192,"html_url":"http://10.0.2.15:3000/learning/control-repo","ssh_url":"git@10.0.2.15:learning/control-repo.git","clone_url":"http://10.0.2.15:3000/learning/control-repo.git","website":"","stars_count":0,"forks_count":0,"watchers_count":1,"open_issues_count":0,"default_branch":"production","created_at":"2018-12-21T21:39:05-08:00","updated_at":"2018-12-21T21:42:26-08:00","permissions":{"admin":true,"push":true,"pull":true}}
```

Thanks,
Robert