### PR TITLE
Clean up all of the SSL certs, even on the master

### DIFF
--- a/tests/scripts/setup
+++ b/tests/scripts/setup
@@ -126,7 +126,7 @@ def clear_nodes
   hosts = docker_hosts
   hosts.each do |name, ip|
     `systemctl stop docker-#{name}.service`
-    `/bin/find /etc/docker/ssl_dir -name #{name}.pem -delete`
+    `/bin/find /etc/docker/ssl_dir /etc/puppetlabs/puppet/ssl -name #{name}.pem -delete`
     `/opt/puppetlabs/bin/puppetserver ca clean --certname #{name}`
   end
 end


### PR DESCRIPTION
This fix cleans up the agent node (Docker container) certificates both from the Docker-mounted directory as well as the master's SSL directory. Prior to this, certificates did not generate automatically due to leftover files in the master's SSL directory. Eventually, it appeared as though the first Puppet run in the container would generate the files, but it was too late to automatically sign them at that point, leaving it to the user to sign the agent node's certificate.

This problem appeared after updating the LVM with PE 2019.0.1, but I'm not sure if it is related to that or was just exposed by some other timing-related issue/race condition.