### PR TITLE
Typo fixes

### DIFF
--- a/en_us/quests/control_repository.md
+++ b/en_us/quests/control_repository.md
@@ -589,7 +589,7 @@ the node:
 
 ## Control repository development workflow
 
-Now that Puppet is running with code depolyed from your control repository,
+Now that Puppet is running with code deployed from your control repository,
 let's walk through the process of introducing changes to your a local copy of
 the repository, creating a PR to merge those changes to your upstream
 repository, and finally deploying those changes to production.

--- a/en_us/quests/control_repository.md
+++ b/en_us/quests/control_repository.md
@@ -146,7 +146,7 @@ Copy the site-specific `cowsay`, `pasture`, `motd`, `user_accounts`, `role`,
 and `profile` Puppet modules into the your control repository's `site`
 directory.
 
-    cp -r {pasture,motd,user_accounts,role,profile} /root/control-repo/site/
+    cp -r {cowsay,pasture,motd,user_accounts,role,profile} /root/control-repo/site/
 
 <div class = "lvm-task-number"><p>Task 3:</p></div>
 

--- a/en_us/quests/defined_resource_types.md
+++ b/en_us/quests/defined_resource_types.md
@@ -450,7 +450,7 @@ iterator allows you to repeat a block of Puppet code multiple times, using
 data from a hash or array to bind different values to the variables in
 the block for each iteration. In this case, the iterator goes through a
 list of users accounts defined in your Hiera data source and declares an
-instance of the `user_accoutns::ssh_user` defined resource type for each.
+instance of the `user_accounts::ssh_user` defined resource type for each.
 
 [//]: # (code/130_defined_resource_types/modules/profile/manifests/base/dev_users.pp)
 

--- a/ja_jp/quests/control_repository.md
+++ b/ja_jp/quests/control_repository.md
@@ -79,7 +79,7 @@ Puppetコードマネージャを使用して、master上の環境に制御リ�
 
 サイト固有のPuppetモジュールである`cowsay`、`pasture`、`motd`、`user_accounts`、`role`、`profile`を、制御リポジトリの`site`ディレクトリにコピーします。
 
-    cp -r {pasture,motd,user_accounts,role,profile} /root/control-repo/site/
+    cp -r {cowsay,pasture,motd,user_accounts,role,profile} /root/control-repo/site/
 
 <div class = "lvm-task-number"><p>タスク3:</p></div>
 

--- a/ja_jp/quests/defined_resource_types.md
+++ b/ja_jp/quests/defined_resource_types.md
@@ -297,7 +297,7 @@ profile::base::dev_users::users: []
 
 これで、`user_accounts::ssh_user`定義リソース型が、ひと組のパラメータ入力からのSSH鍵を利用して新しいユーザアカウントを作成する方法を提供し、Hieraデータファイルが各ユーザのための入力リストを定義するよう設定されました。しかし、コードにおいてこれらのデータを組み合わせる方法についてはまだ取り組んでいません。
 
-ここで、[イテレータ](https://puppet.com/docs/puppet/latest/lang_iteration.html)と呼ばれるPuppet言語の機能を使用します。イテレータを使用すると、Puppetコードのブロックを複数回反復することができます。このとき、ハッシュまたは配列のデータを使用して、各反復につき、ブロック内の変数に異なる値をバインドします。今回の場合、イテレータはHieraデータソースで定義されたユーザアカウントのリストを処理して、それぞれについて`user_accoutns::ssh_user`定義リソース型のインスタンスを宣言します。
+ここで、[イテレータ](https://puppet.com/docs/puppet/latest/lang_iteration.html)と呼ばれるPuppet言語の機能を使用します。イテレータを使用すると、Puppetコードのブロックを複数回反復することができます。このとき、ハッシュまたは配列のデータを使用して、各反復につき、ブロック内の変数に異なる値をバインドします。今回の場合、イテレータはHieraデータソースで定義されたユーザアカウントのリストを処理して、それぞれについて`user_accounts::ssh_user`定義リソース型のインスタンスを宣言します。
 
 [//]: # (code/130_defined_resource_types/modules/profile/manifests/base/dev_users.pp)
 

--- a/tests/control_repository_spec.rb
+++ b/tests/control_repository_spec.rb
@@ -30,11 +30,13 @@ end
 
 describe _("Task 2:"), host: :localhost do
   it 'has a working solution', :solution do
-    command("yes | cp -r /etc/puppetlabs/code/environments/production/modules/{pasture,motd,user_accounts,role,profile} /root/control-repo/site/")
+    command("yes | cp -r /etc/puppetlabs/code/environments/production/modules/{cowsay,pasture,motd,user_accounts,role,profile} /root/control-repo/site/")
       .exit_status
       .should eq 0
   end
   it _('Copy site modules to your control repository'), :validation do
+    file("/root/control-repo/site/cowsay")
+      .should be_directory
     file("/root/control-repo/site/pasture")
       .should be_directory
     file("/root/control-repo/site/motd")


### PR DESCRIPTION
Just a few typo fixes. Also adds the `cowsay` module mentioned in the paragraph describing the example copy command (it was missing for some reason).

Hope you're having a great day! :)