### PR TITLE
Fix inconsistent pasture port variable name

### DIFF
--- a/quests/params_pattern.md
+++ b/quests/params_pattern.md
@@ -8,7 +8,7 @@ parameters for the Pasture class, for example, look like the following:
 
 ```puppet
 class pasture (
-  $pasture_port        = '80',
+  $port                = '80',
   $environment         = 'production',
   $default_character   = 'sheep',
   $default_message     = '',
@@ -38,13 +38,13 @@ the module to be used. A module intended to be published on the Forge for
 general use by the community will generally be as flexible as possible, while
 a
 
-The `pasture::params` class will assign static defaults to the `$pasture_port`
+The `pasture::params` class will assign static defaults to the `$port`
 and `$pasture_config_file` variables, then use a conditional statement to
 assign a different value to the `$default_character` depending on the
 `os.family` fact.
 
 ```puppet
 class pasture::params {
-  $pasture_port = '80',
+  $port = '80',
   $
 }

--- a/quests/variables_and_templates.md
+++ b/quests/variables_and_templates.md
@@ -103,7 +103,7 @@ class pasture {
 }
 ```
 
-We haven't yet done anything with the `$pasture_port` or `$default_character`
+We haven't yet done anything with the `$port` or `$default_character`
 variables. To use these, we need a way to pass them into our configuration
 file. We'll also need to pass the `$pasture_config_file` variable to our
 service unit file so the service will start our Pasture process with the


### PR DESCRIPTION
The variable is called `pasture_port` instead of `port` in a few places.
This change updates the misnamed variables.